### PR TITLE
Fix running session start type to accept null project

### DIFF
--- a/app/src/features/time-tracker/hooks/data/useRunningSessionState.ts
+++ b/app/src/features/time-tracker/hooks/data/useRunningSessionState.ts
@@ -21,7 +21,7 @@ export type UseRunningSessionStateOptions = {
 
 export type RunningSessionStateApi = {
   state: RunningSessionState;
-  start: (title: string, project?: string) => boolean;
+  start: (title: string, project?: string | null) => boolean;
   stop: () => TimeTrackerSession | null;
   updateDraft: (partial: Partial<Omit<SessionDraft, 'startedAt'>>) => void;
   adjustDuration: (deltaSeconds: number) => void;


### PR DESCRIPTION
## Summary
- allow the running session state API to accept null project values so the page handlers can call start without type errors

## Testing
- npx tsc --noEmit
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68f83cde8ac083268a99f3d18133acd5