### PR TITLE
Add build job to feature branch CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,24 @@ jobs:
       - run: npm run test
         working-directory: app
 
+  app-build:
+    name: App - Build
+    runs-on: ubuntu-latest
+    needs:
+      - app-lint
+      - app-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+      - run: npm ci
+        working-directory: app
+      - run: npm run build
+        working-directory: app
+
   app-e2e:
     name: App - E2E Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an app build job that runs `npm run build` after lint and test jobs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f84099eb708326a3e2ba27196fe3d4