### PR TITLE
feat(api): add time tracker worker API and auth hardening

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
-# Google Spreadsheet Sync Worker
+# Forge API Worker
 
-Time TrackerのセッションをGoogle Spreadsheetsへ同期するためのCloudflare Workerです。
+Time Trackerの本体状態とGoogle Spreadsheets同期を扱うCloudflare Workerです。
 
 ## 機能
 
@@ -8,6 +8,7 @@ Time TrackerのセッションをGoogle Spreadsheetsへ同期するためのClou
 - **トークン自動リフレッシュ**: アクセストークンの期限切れ5分前に自動更新
 - **スプレッドシート操作**: Google Sheets APIを使用した読み書き
 - **セッション同期**: Time Trackerのセッションをスプレッドシートへ自動追記
+- **Time Tracker 本体API**: 実行中セッションの開始・更新・停止・キャンセルをSupabaseへ保存
 - **カラムマッピング**: フィールドとスプレッドシート列の柔軟なマッピング（列記号・ヘッダー名対応）
 - **エラーハンドリング**: 同期失敗時のログ記録とリトライ機能
 
@@ -26,6 +27,15 @@ Time TrackerのセッションをGoogle Spreadsheetsへ同期するためのClou
 
 ### 同期
 - `POST /integrations/google/sync` - セッションをスプレッドシートへ同期
+
+### Time Tracker 本体
+- `GET /time-tracker/running` - 実行中セッション状態を取得
+- `POST /time-tracker/running/start` - 実行中セッションを開始
+- `PATCH /time-tracker/running/update` - 実行中セッションの下書き・経過秒数を更新
+- `POST /time-tracker/running/stop` - 実行中セッションを完了セッションとして保存し、実行中状態を解除
+- `POST /time-tracker/running/cancel` - 実行中状態をキャンセル
+
+現時点の Time Tracker 本体APIはSupabaseのcanonical stateを更新します。Google Sheetsへの同期統合とフロントエンド移行は別sliceで扱います。
 
 ## ローカル開発
 
@@ -66,6 +76,8 @@ wrangler secret put SUPABASE_SERVICE_ROLE_KEY
 wrangler secret put GOOGLE_CLIENT_ID
 wrangler secret put GOOGLE_CLIENT_SECRET
 wrangler secret put GOOGLE_REDIRECT_URI
+wrangler secret put OAUTH_STATE_SIGNING_SECRET
+wrangler secret put TOKEN_ENCRYPTION_KEY
 ```
 
 ## 環境変数
@@ -77,6 +89,14 @@ wrangler secret put GOOGLE_REDIRECT_URI
 | `GOOGLE_CLIENT_ID` | Google OAuth クライアント ID | ✓ |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth クライアント シークレット | ✓ |
 | `GOOGLE_REDIRECT_URI` | OAuth リダイレクト URI | ✓ |
+| `OAUTH_STATE_SIGNING_SECRET` | Google OAuth state をHMAC署名するための32 byte以上のランダム値 | ✓ |
+| `TOKEN_ENCRYPTION_KEY` | Google OAuth token をAES-GCM暗号化する32 byte key | ✓ |
+
+`TOKEN_ENCRYPTION_KEY` は32 byteのランダム値をbase64/base64urlまたは64桁hexで設定します。
+
+```bash
+openssl rand -base64 32
+```
 
 ## アーキテクチャ
 
@@ -90,9 +110,13 @@ src/
 ├── handlers/
 │   ├── oauth.ts             # OAuth認証ハンドラー
 │   ├── settings.ts          # 設定管理ハンドラー
-│   └── syncSession.ts       # セッション同期ハンドラー
+│   ├── syncSession.ts       # セッション同期ハンドラー
+│   └── timeTracker.ts       # Time Tracker 本体APIハンドラー
 ├── repositories/
-│   └── googleConnections.ts # Supabase データアクセス層
+│   ├── googleConnections.ts # Google連携用Supabase データアクセス層
+│   └── timeTracker.ts      # Time Tracker用Supabase データアクセス層
+├── security/
+│   └── tokenCrypto.ts       # Google OAuth token の暗号化
 ├── services/
 │   └── googleSheetsClient.ts # Google Sheets API クライアント
 └── http/
@@ -102,8 +126,12 @@ src/
 ## セキュリティ
 
 - すべてのエンドポイントでSupabase JWTによる認証が必要
-- Google OAuth トークンは暗号化してSupabaseに保存
+- Google OAuth stateはHMAC署名し、10分で期限切れにする
+- Google OAuth トークンはAES-GCMで暗号化してSupabaseに保存
+- 既存の平文token行は移行期間中のみ読み取り互換を残し、再連携またはtoken refresh時に暗号化形式へ更新する
 - Row Level Security (RLS) によるデータアクセス制御
+- WorkerはService RoleでSupabase RESTを呼ぶため、request bodyの`user_id`を信用せず、検証済みJWTのuser idだけを永続化に使う
+- CORSは `https://forge.h031203yama.workers.dev` とローカル開発originに限定し、未知originは既定originへフォールバックする
 - シークレット情報は環境変数として管理（コードに含めない）
 
 ## 詳細なセットアップ手順

--- a/api/src/__tests__/securityBoundaries.test.ts
+++ b/api/src/__tests__/securityBoundaries.test.ts
@@ -1,0 +1,64 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getCorsHeaders } from '../http/response';
+
+const readSourceFiles = (root: string): string[] => {
+  const entries = readdirSync(root);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const path = join(root, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...readSourceFiles(path));
+      continue;
+    }
+    if (['.ts', '.tsx'].includes(extname(path))) {
+      files.push(path);
+    }
+  }
+
+  return files;
+};
+
+describe('security boundary static checks', () => {
+  it('does not expose Supabase service role material to the browser app', () => {
+    const appRoot = resolve(process.cwd(), '../app/src');
+    const source = readSourceFiles(appRoot)
+      .map((path) => readFileSync(path, 'utf8'))
+      .join('\n');
+
+    expect(source).not.toMatch(/SUPABASE_SERVICE_ROLE_KEY/);
+    expect(source).not.toMatch(/service[_-]?role/i);
+  });
+
+  it('keeps canonical time-tracker writes independent from request body user ids', () => {
+    const handlerSource = readFileSync(
+      resolve(process.cwd(), 'src/handlers/timeTracker.ts'),
+      'utf8',
+    );
+
+    expect(handlerSource).not.toMatch(/\bbody\.(user_id|userId)\b/);
+    expect(handlerSource).not.toMatch(/\b(user_id|userId)\s*=\s*body\b/);
+  });
+
+  it('does not expose Google OAuth tokens in browser-facing Google sync contracts', () => {
+    const contractSource = readFileSync(
+      resolve(process.cwd(), '../app/src/features/time-tracker/domain/googleSyncTypes.ts'),
+      'utf8',
+    );
+
+    expect(contractSource).not.toMatch(/\b(access_token|refresh_token)\b/);
+    expect(contractSource).not.toMatch(/\b(accessToken|refreshToken)\b/);
+  });
+
+  it('does not fall back to wildcard CORS origins', () => {
+    expect(getCorsHeaders('https://evil.example')['Access-Control-Allow-Origin']).toBe(
+      'https://forge.h031203yama.workers.dev',
+    );
+    expect(getCorsHeaders('http://localhost:5173')['Access-Control-Allow-Origin']).toBe(
+      'http://localhost:5173',
+    );
+  });
+});

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -4,4 +4,6 @@ export interface Env {
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
   GOOGLE_REDIRECT_URI: string;
+  OAUTH_STATE_SIGNING_SECRET?: string;
+  TOKEN_ENCRYPTION_KEY?: string;
 }

--- a/api/src/handlers/__tests__/oauth.test.ts
+++ b/api/src/handlers/__tests__/oauth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { handleOauthCallback, handleOauthRevoke, handleOauthStart } from '../oauth';
 
 const env = {
@@ -7,6 +7,8 @@ const env = {
   GOOGLE_CLIENT_ID: 'client-123',
   GOOGLE_CLIENT_SECRET: 'secret-xyz',
   GOOGLE_REDIRECT_URI: 'https://worker.example.com/oauth/callback',
+  OAUTH_STATE_SIGNING_SECRET: 'state-signing-secret-for-tests-32b',
+  TOKEN_ENCRYPTION_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
 } as const;
 
 const buildRequest = (
@@ -38,6 +40,43 @@ const mocks = vi.hoisted(() => {
     getConnectionByUser,
   };
 });
+
+const extractStateFromStartResponse = async (response: Response): Promise<string> => {
+  const payload = (await response.json()) as { authorizationUrl: string };
+  const url = new URL(payload.authorizationUrl);
+  const state = url.searchParams.get('state');
+  if (!state) {
+    throw new Error('Missing state');
+  }
+  return state;
+};
+
+const decodeSignedStatePayload = (
+  state: string,
+): { userId: string; redirectPath: string; nonce: string; exp: number } => {
+  const [encodedPayload] = state.split('.');
+  return JSON.parse(Buffer.from(encodedPayload ?? '', 'base64url').toString('utf8')) as {
+    userId: string;
+    redirectPath: string;
+    nonce: string;
+    exp: number;
+  };
+};
+
+const tamperStateUserId = (state: string, userId: string): string => {
+  const [encodedPayload, signature] = state.split('.');
+  const payload = JSON.parse(Buffer.from(encodedPayload ?? '', 'base64url').toString('utf8')) as {
+    userId: string;
+  };
+  const tamperedPayload = Buffer.from(
+    JSON.stringify({
+      ...payload,
+      userId,
+    }),
+    'utf8',
+  ).toString('base64url');
+  return `${tamperedPayload}.${signature}`;
+};
 
 vi.mock('../../auth/verifySupabaseJwt', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../auth/verifySupabaseJwt')>();
@@ -112,28 +151,51 @@ describe('oauth handlers', () => {
       expect(scopes).toContain('https://www.googleapis.com/auth/spreadsheets');
       const state = url.searchParams.get('state');
       expect(state).toBeTruthy();
-      const decoded = JSON.parse(Buffer.from(state ?? '', 'base64url').toString('utf8')) as {
-        userId: string;
-        redirectPath: string;
-        nonce: string;
-      };
+      expect(state?.split('.')).toHaveLength(2);
+      const decoded = decodeSignedStatePayload(state ?? '');
       expect(decoded.userId).toBe('user-1');
       expect(decoded.redirectPath).toBe('/app/dashboard');
       expect(typeof decoded.nonce).toBe('string');
+      expect(decoded.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('rejects absolute redirect paths', async () => {
+      mocks.verifySupabaseJwt.mockResolvedValue({ userId: 'user-1', raw: {} });
+
+      const response = await handleOauthStart(
+        buildRequest('https://example.com/integrations/google/oauth/start', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token-123',
+            'Content-Type': 'application/json',
+          },
+          body: { redirectPath: 'https://evil.example/callback' },
+        }),
+        env,
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: 'bad_request',
+      });
     });
   });
 
   describe('handleOauthCallback', () => {
     it('exchanges code and stores connection', async () => {
       mocks.verifySupabaseJwt.mockResolvedValue({ userId: 'user-1', raw: {} });
-      const state = Buffer.from(
-        JSON.stringify({
-          userId: 'user-1',
-          redirectPath: '/app/dashboard',
-          nonce: 'abc123',
+      const startResponse = await handleOauthStart(
+        buildRequest('https://example.com/integrations/google/oauth/start', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token-123',
+            'Content-Type': 'application/json',
+          },
+          body: { redirectPath: '/app/dashboard' },
         }),
-        'utf8',
-      ).toString('base64url');
+        env,
+      );
+      const state = await extractStateFromStartResponse(startResponse);
 
       const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
       const payload = Buffer.from(
@@ -147,7 +209,7 @@ describe('oauth handlers', () => {
         token_type: 'Bearer',
         id_token: `${header}.${payload}.signature`,
       };
-      (fetch as unknown as vi.Mock).mockResolvedValue(
+      (fetch as unknown as Mock).mockResolvedValue(
         new Response(JSON.stringify(tokenResponse), { status: 200 }),
       );
 
@@ -179,6 +241,33 @@ describe('oauth handlers', () => {
       expect(response.status).toBe(302);
       expect(response.headers.get('Location')).toContain('/app/dashboard');
     });
+
+    it('rejects tampered state before exchanging the authorization code', async () => {
+      mocks.verifySupabaseJwt.mockResolvedValue({ userId: 'user-1', raw: {} });
+      const startResponse = await handleOauthStart(
+        buildRequest('https://example.com/integrations/google/oauth/start', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token-123',
+            'Content-Type': 'application/json',
+          },
+          body: { redirectPath: '/app/dashboard' },
+        }),
+        env,
+      );
+      const state = tamperStateUserId(await extractStateFromStartResponse(startResponse), 'user-2');
+
+      const response = await handleOauthCallback(
+        buildRequest(
+          `https://example.com/integrations/google/oauth/callback?code=auth-code&state=${state}`,
+        ),
+        env,
+      );
+
+      expect(response.status).toBe(400);
+      expect(fetch).not.toHaveBeenCalled();
+      expect(mocks.upsertConnection).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleOauthRevoke', () => {
@@ -199,7 +288,7 @@ describe('oauth handlers', () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       });
-      (fetch as unknown as vi.Mock).mockResolvedValue(new Response(null, { status: 200 }));
+      (fetch as unknown as Mock).mockResolvedValue(new Response(null, { status: 200 }));
 
       const response = await handleOauthRevoke(
         buildRequest('https://example.com/integrations/google/oauth/revoke', {

--- a/api/src/handlers/__tests__/timeTracker.test.ts
+++ b/api/src/handlers/__tests__/timeTracker.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  handleCancelRunningSession,
+  handleGetRunningState,
+  handleStartRunningSession,
+  handleStopRunningSession,
+  handleUpdateRunningSession,
+} from '../timeTracker';
+
+const mocks = vi.hoisted(() => {
+  const verifySupabaseJwt = vi.fn();
+  const getRunningState = vi.fn();
+  const upsertRunningState = vi.fn();
+  const insertSession = vi.fn();
+  return {
+    verifySupabaseJwt,
+    getRunningState,
+    upsertRunningState,
+    insertSession,
+  };
+});
+
+vi.mock('../../auth/verifySupabaseJwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/verifySupabaseJwt')>();
+  return {
+    ...actual,
+    verifySupabaseJwt: mocks.verifySupabaseJwt,
+  };
+});
+
+vi.mock('../../repositories/timeTracker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../repositories/timeTracker')>();
+  return {
+    ...actual,
+    getRunningState: mocks.getRunningState,
+    upsertRunningState: mocks.upsertRunningState,
+    insertSession: mocks.insertSession,
+  };
+});
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: '',
+  GOOGLE_CLIENT_SECRET: '',
+  GOOGLE_REDIRECT_URI: '',
+} as const;
+
+const buildRequest = (method: string, path: string, body?: unknown) =>
+  new Request(`https://example.com${path}`, {
+    method,
+    headers: {
+      Authorization: 'Bearer supabase-token',
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+const draft = {
+  id: 'session-1',
+  title: 'Focus',
+  startedAt: '2026-04-30T00:00:00.000Z',
+  project: 'Forge',
+  tags: ['mcp'],
+  notes: 'local test',
+};
+
+const runningState = {
+  status: 'running' as const,
+  draft,
+  elapsedSeconds: 0,
+};
+
+const idleState = {
+  status: 'idle' as const,
+  draft: null,
+  elapsedSeconds: 0,
+};
+
+describe('time tracker canonical Worker handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.verifySupabaseJwt.mockResolvedValue({
+      userId: 'user-1',
+      raw: {},
+    });
+  });
+
+  it('returns idle state when the user has no running row', async () => {
+    mocks.getRunningState.mockResolvedValue(null);
+
+    const response = await handleGetRunningState(buildRequest('GET', '/time-tracker/running'), env);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ state: idleState });
+    expect(mocks.getRunningState).toHaveBeenCalledWith(env, 'user-1');
+  });
+
+  it('starts a running session using the verified user id only', async () => {
+    mocks.getRunningState.mockResolvedValue(null);
+    mocks.upsertRunningState.mockResolvedValue(runningState);
+
+    const response = await handleStartRunningSession(
+      buildRequest('POST', '/time-tracker/running/start', {
+        user_id: 'attacker-user',
+        draft,
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ state: runningState });
+    expect(mocks.upsertRunningState).toHaveBeenCalledWith(env, 'user-1', runningState);
+  });
+
+  it('rejects start when another session is already running', async () => {
+    mocks.getRunningState.mockResolvedValue({
+      ...runningState,
+      draft: { ...draft, id: 'other-session' },
+    });
+
+    const response = await handleStartRunningSession(
+      buildRequest('POST', '/time-tracker/running/start', { draft }),
+      env,
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'already_running' });
+    expect(mocks.upsertRunningState).not.toHaveBeenCalled();
+  });
+
+  it('updates the current running state when the draft id matches', async () => {
+    mocks.getRunningState.mockResolvedValue(runningState);
+    mocks.upsertRunningState.mockResolvedValue({
+      ...runningState,
+      elapsedSeconds: 120,
+    });
+
+    const response = await handleUpdateRunningSession(
+      buildRequest('PATCH', '/time-tracker/running/update', {
+        draft: { ...draft, title: 'Deep Work' },
+        elapsedSeconds: 120,
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.upsertRunningState).toHaveBeenCalledWith(env, 'user-1', {
+      status: 'running',
+      draft: { ...draft, title: 'Deep Work' },
+      elapsedSeconds: 120,
+    });
+  });
+
+  it('stops the running session, creates a completed session, and clears running state', async () => {
+    const stoppedAt = '2026-04-30T00:05:00.000Z';
+    const completedSession = {
+      id: 'session-1',
+      title: 'Focus',
+      startedAt: draft.startedAt,
+      endedAt: stoppedAt,
+      durationSeconds: 300,
+      project: 'Forge',
+      tags: ['mcp'],
+      notes: 'local test',
+    };
+    mocks.getRunningState.mockResolvedValue(runningState);
+    mocks.insertSession.mockResolvedValue(completedSession);
+    mocks.upsertRunningState.mockResolvedValue(idleState);
+
+    const response = await handleStopRunningSession(
+      buildRequest('POST', '/time-tracker/running/stop', { id: 'session-1', stoppedAt }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      session: completedSession,
+      state: idleState,
+    });
+    expect(mocks.insertSession).toHaveBeenCalledWith(env, 'user-1', completedSession);
+    expect(mocks.upsertRunningState).toHaveBeenCalledWith(env, 'user-1', idleState);
+  });
+
+  it('cancels the current running session without creating a completed session', async () => {
+    mocks.getRunningState.mockResolvedValue(runningState);
+    mocks.upsertRunningState.mockResolvedValue(idleState);
+
+    const response = await handleCancelRunningSession(
+      buildRequest('POST', '/time-tracker/running/cancel', { id: 'session-1' }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ state: idleState });
+    expect(mocks.insertSession).not.toHaveBeenCalled();
+    expect(mocks.upsertRunningState).toHaveBeenCalledWith(env, 'user-1', idleState);
+  });
+});

--- a/api/src/handlers/oauth.ts
+++ b/api/src/handlers/oauth.ts
@@ -18,9 +18,14 @@ type OauthStatePayload = {
   nonce: string;
 };
 
+type SignedOauthStatePayload = OauthStatePayload & {
+  exp: number;
+};
+
 const GOOGLE_AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const GOOGLE_REVOKE_ENDPOINT = 'https://oauth2.googleapis.com/revoke';
+const OAUTH_STATE_TTL_SECONDS = 10 * 60;
 
 const DEFAULT_SCOPES = [
   'openid',
@@ -30,55 +35,172 @@ const DEFAULT_SCOPES = [
   'https://www.googleapis.com/auth/drive.readonly',
 ];
 
+const bytesToBase64Url = (bytes: Uint8Array): string => {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+};
+
+const base64UrlToBytes = (value: string): Uint8Array => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+};
+
 const toBase64Url = (input: string): string => {
   if (typeof btoa === 'function') {
-    const bytes = new TextEncoder().encode(input);
-    let binary = '';
-    bytes.forEach((b) => {
-      binary += String.fromCharCode(b);
-    });
-    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+    return bytesToBase64Url(new TextEncoder().encode(input));
   }
   return Buffer.from(input, 'utf8').toString('base64url');
 };
 
 const fromBase64Url = (value: string): string => {
   if (typeof atob === 'function') {
-    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
-    const binary = atob(normalized);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-    return new TextDecoder().decode(bytes);
+    return new TextDecoder().decode(base64UrlToBytes(value));
   }
   return Buffer.from(value, 'base64url').toString('utf8');
 };
 
-const encodeState = (payload: OauthStatePayload): string => toBase64Url(JSON.stringify(payload));
+const stateSigningSecret = (env: Env): string => {
+  if (!env.OAUTH_STATE_SIGNING_SECRET || env.OAUTH_STATE_SIGNING_SECRET.trim().length === 0) {
+    throw new Error('OAuth state signing secret is not configured');
+  }
+  if (new TextEncoder().encode(env.OAUTH_STATE_SIGNING_SECRET).byteLength < 32) {
+    throw new Error('OAuth state signing secret must be at least 32 bytes');
+  }
+  return env.OAUTH_STATE_SIGNING_SECRET;
+};
 
-const decodeState = (value: string): OauthStatePayload => {
+const importStateSigningKey = (secret: string): Promise<CryptoKey> =>
+  crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  );
+
+const signStatePayload = async (encodedPayload: string, secret: string): Promise<string> => {
+  const key = await importStateSigningKey(secret);
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(encodedPayload));
+  return bytesToBase64Url(new Uint8Array(signature));
+};
+
+const verifyStateSignature = async (
+  encodedPayload: string,
+  encodedSignature: string,
+  secret: string,
+): Promise<boolean> => {
+  const key = await importStateSigningKey(secret);
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    base64UrlToBytes(encodedSignature),
+    new TextEncoder().encode(encodedPayload),
+  );
+};
+
+const buildNonce = (): string => {
+  const randomUUID = globalThis.crypto.randomUUID;
+  if (typeof randomUUID === 'function') {
+    return randomUUID.call(globalThis.crypto);
+  }
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytesToBase64Url(bytes);
+};
+
+const encodeState = async (payload: OauthStatePayload, env: Env): Promise<string> => {
+  const signedPayload: SignedOauthStatePayload = {
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + OAUTH_STATE_TTL_SECONDS,
+  };
+  const encodedPayload = toBase64Url(JSON.stringify(signedPayload));
+  const signature = await signStatePayload(encodedPayload, stateSigningSecret(env));
+  return `${encodedPayload}.${signature}`;
+};
+
+const decodeState = async (value: string, env: Env): Promise<OauthStatePayload> => {
   try {
-    const json = fromBase64Url(value);
-    const parsed = JSON.parse(json) as Partial<OauthStatePayload>;
+    const [encodedPayload, encodedSignature, extra] = value.split('.');
+    if (!encodedPayload || !encodedSignature || extra !== undefined) {
+      throw new Error('Invalid state payload');
+    }
+
+    const verified = await verifyStateSignature(
+      encodedPayload,
+      encodedSignature,
+      stateSigningSecret(env),
+    );
+    if (!verified) {
+      throw new Error('Invalid state signature');
+    }
+
+    const json = fromBase64Url(encodedPayload);
+    const parsed = JSON.parse(json) as Partial<SignedOauthStatePayload>;
     if (
       !parsed ||
       typeof parsed.userId !== 'string' ||
       typeof parsed.redirectPath !== 'string' ||
-      typeof parsed.nonce !== 'string'
+      typeof parsed.nonce !== 'string' ||
+      typeof parsed.exp !== 'number'
     ) {
       throw new Error('Invalid state payload');
     }
-    return parsed as OauthStatePayload;
+    if (parsed.exp < Math.floor(Date.now() / 1000)) {
+      throw new Error('Expired state');
+    }
+    return {
+      userId: parsed.userId,
+      redirectPath: parsed.redirectPath,
+      nonce: parsed.nonce,
+    };
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : 'Invalid state payload');
   }
 };
 
-const ensureEnv = (env: Env) => {
+const ensureGoogleEnv = (env: Env) => {
   if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET || !env.GOOGLE_REDIRECT_URI) {
     throw new Error('Google OAuth environment variables are not configured');
   }
 };
 
-const getAuthorizationUrl = (env: Env, state: OauthStatePayload, redirectPath: string): string => {
+const ensureOauthFlowEnv = (env: Env) => {
+  ensureGoogleEnv(env);
+  stateSigningSecret(env);
+  if (!env.TOKEN_ENCRYPTION_KEY || env.TOKEN_ENCRYPTION_KEY.trim().length === 0) {
+    throw new Error('Token encryption key is not configured');
+  }
+};
+
+const normalizeRedirectPath = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (
+    trimmed.length === 0 ||
+    !trimmed.startsWith('/') ||
+    trimmed.startsWith('//') ||
+    trimmed.includes('\\') ||
+    /[\r\n]/u.test(trimmed)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed, 'https://forge.local');
+    if (parsed.origin !== 'https://forge.local') {
+      return null;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
+  }
+};
+
+const getAuthorizationUrl = (env: Env, stateValue: string): string => {
   const url = new URL(GOOGLE_AUTH_ENDPOINT);
   url.searchParams.set('client_id', env.GOOGLE_CLIENT_ID);
   url.searchParams.set('redirect_uri', env.GOOGLE_REDIRECT_URI);
@@ -86,7 +208,7 @@ const getAuthorizationUrl = (env: Env, state: OauthStatePayload, redirectPath: s
   url.searchParams.set('access_type', 'offline');
   url.searchParams.set('prompt', 'consent');
   url.searchParams.set('scope', DEFAULT_SCOPES.join(' '));
-  url.searchParams.set('state', encodeState({ ...state, redirectPath }));
+  url.searchParams.set('state', stateValue);
   return url.toString();
 };
 
@@ -134,7 +256,7 @@ export const refreshAccessToken = async (
   accessToken: string;
   expiresAt: string;
 }> => {
-  ensureEnv(env);
+  ensureGoogleEnv(env);
 
   const body = new URLSearchParams({
     client_id: env.GOOGLE_CLIENT_ID,
@@ -196,7 +318,7 @@ export const ensureValidAccessToken = async (
   );
 
   // DBを更新
-  await updateAccessToken(env, connection.id, accessToken, newExpiresAt);
+  await updateAccessToken(env, connection.id, accessToken, newExpiresAt, connection.refresh_token);
 
   return accessToken;
 };
@@ -218,9 +340,13 @@ export const handleOauthStart = async (request: Request, env: Env): Promise<Resp
   if (typeof payload.redirectPath !== 'string' || payload.redirectPath.trim().length === 0) {
     return badRequest('redirectPath is required');
   }
+  const redirectPath = normalizeRedirectPath(payload.redirectPath);
+  if (!redirectPath) {
+    return badRequest('redirectPath must be an app-relative path');
+  }
 
   try {
-    ensureEnv(env);
+    ensureOauthFlowEnv(env);
   } catch (error) {
     return serverError(
       error instanceof Error ? error.message : 'Missing Google OAuth configuration',
@@ -240,14 +366,12 @@ export const handleOauthStart = async (request: Request, env: Env): Promise<Resp
 
   const state: OauthStatePayload = {
     userId: auth.userId,
-    redirectPath: payload.redirectPath,
-    nonce:
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : Math.random().toString(36).slice(2),
+    redirectPath,
+    nonce: buildNonce(),
   };
 
-  const authorizationUrl = getAuthorizationUrl(env, state, payload.redirectPath);
+  const stateValue = await encodeState(state, env);
+  const authorizationUrl = getAuthorizationUrl(env, stateValue);
 
   return jsonResponse({ authorizationUrl });
 };
@@ -260,20 +384,20 @@ export const handleOauthCallback = async (request: Request, env: Env): Promise<R
     return badRequest('code and state are required');
   }
 
-  let state: OauthStatePayload;
   try {
-    state = decodeState(stateValue);
-  } catch (error) {
-    return badRequest(error instanceof Error ? error.message : 'Invalid state');
-  }
-
-  try {
-    ensureEnv(env);
+    ensureOauthFlowEnv(env);
   } catch (error) {
     return serverError(
       error instanceof Error ? error.message : 'Missing Google OAuth configuration',
       500,
     );
+  }
+
+  let state: OauthStatePayload;
+  try {
+    state = await decodeState(stateValue, env);
+  } catch (error) {
+    return badRequest(error instanceof Error ? error.message : 'Invalid state');
   }
 
   const body = new URLSearchParams({

--- a/api/src/handlers/timeTracker.ts
+++ b/api/src/handlers/timeTracker.ts
@@ -1,0 +1,309 @@
+import {
+  extractBearerToken,
+  SupabaseAuthError,
+  verifySupabaseJwt,
+} from '../auth/verifySupabaseJwt';
+import type { Env } from '../env';
+import { badRequest, conflict, jsonResponse, serverError, unauthorized } from '../http/response';
+import {
+  getRunningState,
+  insertSession,
+  TimeTrackerRepositoryError,
+  upsertRunningState,
+} from '../repositories/timeTracker';
+import type {
+  RunningSessionCancelRequest,
+  RunningSessionDraftPayload,
+  RunningSessionStatePayload,
+  RunningSessionStopRequest,
+  RunningSessionUpdateRequest,
+  TimeTrackerSessionPayload,
+} from '../types';
+
+class HttpResponseError extends Error {
+  readonly response: Response;
+
+  constructor(response: Response) {
+    super(`HTTP ${response.status}`);
+    this.response = response;
+  }
+}
+
+const idleState: RunningSessionStatePayload = {
+  status: 'idle',
+  draft: null,
+  elapsedSeconds: 0,
+};
+
+const ensureAuthorized = async (request: Request, env: Env) => {
+  const token = extractBearerToken(request);
+  if (!token) {
+    throw new HttpResponseError(unauthorized('Bearer token is required'));
+  }
+
+  try {
+    return await verifySupabaseJwt(token, env);
+  } catch (error) {
+    if (error instanceof SupabaseAuthError) {
+      throw new HttpResponseError(unauthorized(error.message));
+    }
+    throw new HttpResponseError(unauthorized('Invalid token'));
+  }
+};
+
+const parseJson = async <T>(request: Request): Promise<T> => {
+  try {
+    return (await request.json()) as T;
+  } catch (error) {
+    throw new HttpResponseError(
+      badRequest(error instanceof Error ? error.message : 'Invalid request body'),
+    );
+  }
+};
+
+const asObject = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+};
+
+const validateString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new HttpResponseError(badRequest(`${field} is required`));
+  }
+  return value.trim();
+};
+
+const validateOptionalString = (value: unknown, field: string): string | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new HttpResponseError(badRequest(`${field} must be a string`));
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const validateDraft = (draft: unknown): RunningSessionDraftPayload => {
+  const value = asObject(draft);
+  if (!value) {
+    throw new HttpResponseError(badRequest('draft is required'));
+  }
+
+  const startedAt = validateString(value.startedAt, 'draft.startedAt');
+  if (Number.isNaN(new Date(startedAt).getTime())) {
+    throw new HttpResponseError(badRequest('draft.startedAt must be a valid date string'));
+  }
+
+  const tags = value.tags;
+  if (tags !== undefined && (!Array.isArray(tags) || tags.some((tag) => typeof tag !== 'string'))) {
+    throw new HttpResponseError(badRequest('draft.tags must be an array of strings'));
+  }
+
+  const normalized: RunningSessionDraftPayload = {
+    id: validateString(value.id, 'draft.id'),
+    title: validateString(value.title, 'draft.title'),
+    startedAt,
+  };
+
+  const project = validateOptionalString(value.project, 'draft.project');
+  if (project !== undefined) normalized.project = project;
+  const skill = validateOptionalString(value.skill, 'draft.skill');
+  if (skill !== undefined) normalized.skill = skill;
+  const intensity = validateOptionalString(value.intensity, 'draft.intensity');
+  if (intensity !== undefined) normalized.intensity = intensity;
+  const notes = validateOptionalString(value.notes, 'draft.notes');
+  if (notes !== undefined) normalized.notes = notes;
+  if (Array.isArray(tags)) {
+    normalized.tags = tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+  }
+
+  return normalized;
+};
+
+const validateElapsedSeconds = (elapsedSeconds: unknown): number => {
+  if (typeof elapsedSeconds !== 'number' || Number.isNaN(elapsedSeconds) || elapsedSeconds < 0) {
+    throw new HttpResponseError(badRequest('elapsedSeconds must be a non-negative number'));
+  }
+  return Math.floor(elapsedSeconds);
+};
+
+const requireCurrentRunning = (
+  state: RunningSessionStatePayload | null,
+): Extract<RunningSessionStatePayload, { status: 'running' }> => {
+  if (!state || state.status !== 'running') {
+    throw new HttpResponseError(conflict('no_running_session', 'No running session exists'));
+  }
+  return state;
+};
+
+const ensureSessionIdMatches = (
+  state: Extract<RunningSessionStatePayload, { status: 'running' }>,
+  expectedId?: string,
+) => {
+  if (expectedId && state.draft.id !== expectedId) {
+    throw new HttpResponseError(
+      conflict('running_session_mismatch', 'Running session id does not match'),
+    );
+  }
+};
+
+const parseStoppedAt = (value: unknown): string => {
+  if (value === undefined || value === null) {
+    return new Date().toISOString();
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      throw new HttpResponseError(badRequest('stoppedAt must be a valid timestamp'));
+    }
+    return date.toISOString();
+  }
+  if (typeof value === 'string') {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      throw new HttpResponseError(badRequest('stoppedAt must be a valid date string'));
+    }
+    return date.toISOString();
+  }
+  throw new HttpResponseError(badRequest('stoppedAt must be a date string or timestamp'));
+};
+
+const buildCompletedSession = (
+  draft: RunningSessionDraftPayload,
+  stoppedAt: string,
+): TimeTrackerSessionPayload => {
+  const startedAtMs = new Date(draft.startedAt).getTime();
+  const stoppedAtMs = new Date(stoppedAt).getTime();
+  const durationSeconds = Math.max(1, Math.floor((stoppedAtMs - startedAtMs) / 1000));
+
+  const session: TimeTrackerSessionPayload = {
+    id: draft.id,
+    title: draft.title,
+    startedAt: new Date(startedAtMs).toISOString(),
+    endedAt: stoppedAt,
+    durationSeconds,
+  };
+
+  if (draft.project) session.project = draft.project;
+  if (draft.notes) session.notes = draft.notes;
+  if (draft.tags?.length) session.tags = draft.tags;
+  if (draft.skill) session.skill = draft.skill;
+  if (draft.intensity) session.intensity = draft.intensity;
+
+  return session;
+};
+
+const handleError = (responseOrError: unknown): Response => {
+  if (responseOrError instanceof HttpResponseError) {
+    return responseOrError.response;
+  }
+  if (responseOrError instanceof TimeTrackerRepositoryError) {
+    return serverError(
+      responseOrError.message,
+      responseOrError.status >= 500 ? 502 : responseOrError.status,
+    );
+  }
+  if (responseOrError instanceof Error) {
+    return serverError(responseOrError.message, 500);
+  }
+  return serverError('Unknown error', 500);
+};
+
+export const handleGetRunningState = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureAuthorized(request, env);
+    const state = (await getRunningState(env, auth.userId)) ?? idleState;
+
+    return jsonResponse({ state });
+  } catch (responseOrError) {
+    return handleError(responseOrError);
+  }
+};
+
+export const handleStartRunningSession = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureAuthorized(request, env);
+    const payload = await parseJson<{ draft?: unknown }>(request);
+    const draft = validateDraft(payload.draft);
+    const currentState = await getRunningState(env, auth.userId);
+
+    if (currentState?.status === 'running') {
+      if (currentState.draft.id === draft.id) {
+        return jsonResponse({ state: currentState });
+      }
+      throw new HttpResponseError(conflict('already_running', 'A running session already exists'));
+    }
+
+    const state: RunningSessionStatePayload = {
+      status: 'running',
+      draft,
+      elapsedSeconds: 0,
+    };
+    const savedState = await upsertRunningState(env, auth.userId, state);
+
+    return jsonResponse({ state: savedState }, 201);
+  } catch (responseOrError) {
+    return handleError(responseOrError);
+  }
+};
+
+export const handleUpdateRunningSession = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureAuthorized(request, env);
+    const payload = await parseJson<RunningSessionUpdateRequest>(request);
+    const draft = validateDraft(payload.draft);
+    const elapsedSeconds = validateElapsedSeconds(payload.elapsedSeconds);
+    const currentState = requireCurrentRunning(await getRunningState(env, auth.userId));
+    ensureSessionIdMatches(currentState, draft.id);
+
+    const state: RunningSessionStatePayload = {
+      status: 'running',
+      draft,
+      elapsedSeconds,
+    };
+    const savedState = await upsertRunningState(env, auth.userId, state);
+
+    return jsonResponse({ state: savedState });
+  } catch (responseOrError) {
+    return handleError(responseOrError);
+  }
+};
+
+export const handleStopRunningSession = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureAuthorized(request, env);
+    const payload = await parseJson<RunningSessionStopRequest>(request);
+    const currentState = requireCurrentRunning(await getRunningState(env, auth.userId));
+    ensureSessionIdMatches(currentState, payload.id);
+
+    const stoppedAt = parseStoppedAt(payload.stoppedAt);
+    const session = buildCompletedSession(currentState.draft, stoppedAt);
+    const savedSession = await insertSession(env, auth.userId, session);
+    const savedState = await upsertRunningState(env, auth.userId, idleState);
+
+    return jsonResponse({ session: savedSession, state: savedState });
+  } catch (responseOrError) {
+    return handleError(responseOrError);
+  }
+};
+
+export const handleCancelRunningSession = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureAuthorized(request, env);
+    const payload = await parseJson<RunningSessionCancelRequest>(request);
+    const currentState = await getRunningState(env, auth.userId);
+
+    if (!currentState || currentState.status === 'idle') {
+      return jsonResponse({ state: idleState });
+    }
+    ensureSessionIdMatches(currentState, payload.id);
+
+    const savedState = await upsertRunningState(env, auth.userId, idleState);
+
+    return jsonResponse({ state: savedState });
+  } catch (responseOrError) {
+    return handleError(responseOrError);
+  }
+};

--- a/api/src/http/response.ts
+++ b/api/src/http/response.ts
@@ -1,30 +1,50 @@
-const getCorsHeaders = () => {
-  // 開発環境では全てのオリジンを許可
+const DEFAULT_ALLOWED_ORIGIN = 'https://forge.h031203yama.workers.dev';
+
+const ALLOWED_ORIGINS = new Set([
+  DEFAULT_ALLOWED_ORIGIN,
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:4173',
+]);
+
+const resolveAllowedOrigin = (origin?: string | null): string => {
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    return origin;
+  }
+  return DEFAULT_ALLOWED_ORIGIN;
+};
+
+const getCorsHeaders = (origin?: string | null) => {
   return {
-    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Origin': resolveAllowedOrigin(origin),
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
   };
 };
 
-const jsonResponse = (data: unknown, status = 200) =>
+const jsonResponse = (data: unknown, status = 200, origin?: string | null) =>
   new Response(JSON.stringify(data), {
     status,
     headers: {
       'Content-Type': 'application/json',
-      ...getCorsHeaders(),
+      ...getCorsHeaders(origin),
     },
   });
 
-const badRequest = (message: string) => jsonResponse({ error: 'bad_request', message }, 400);
+const badRequest = (message: string, origin?: string | null) =>
+  jsonResponse({ error: 'bad_request', message }, 400, origin);
 
-const unauthorized = (message: string) => jsonResponse({ error: 'unauthorized', message }, 401);
+const unauthorized = (message: string, origin?: string | null) =>
+  jsonResponse({ error: 'unauthorized', message }, 401, origin);
 
-const conflict = (code: string, message: string) => jsonResponse({ error: code, message }, 409);
+const conflict = (code: string, message: string, origin?: string | null) =>
+  jsonResponse({ error: code, message }, 409, origin);
 
-const serverError = (message: string, status = 500) =>
-  jsonResponse({ error: 'internal_error', message }, status);
+const serverError = (message: string, status = 500, origin?: string | null) =>
+  jsonResponse({ error: 'internal_error', message }, status, origin);
 
 const handleOptions = (request: Request) => {
   const origin = request.headers.get('Origin');

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,7 +12,14 @@ import {
   handleUpdateSettings,
 } from './handlers/settings';
 import { handleDeleteSyncedSession, handleSyncSession } from './handlers/syncSession';
-import { handleOptions } from './http/response';
+import {
+  handleCancelRunningSession,
+  handleGetRunningState,
+  handleStartRunningSession,
+  handleStopRunningSession,
+  handleUpdateRunningSession,
+} from './handlers/timeTracker';
+import { getCorsHeaders, handleOptions } from './http/response';
 
 const ROUTES = {
   SYNC: '/integrations/google/sync',
@@ -25,7 +32,27 @@ const ROUTES = {
   RUNNING_START: '/integrations/google/running/start',
   RUNNING_UPDATE: '/integrations/google/running/update',
   RUNNING_CANCEL: '/integrations/google/running/cancel',
+  TIME_TRACKER_RUNNING: '/time-tracker/running',
+  TIME_TRACKER_RUNNING_START: '/time-tracker/running/start',
+  TIME_TRACKER_RUNNING_UPDATE: '/time-tracker/running/update',
+  TIME_TRACKER_RUNNING_STOP: '/time-tracker/running/stop',
+  TIME_TRACKER_RUNNING_CANCEL: '/time-tracker/running/cancel',
 } as const;
+
+const withCors = (response: Response, request: Request): Response => {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(getCorsHeaders(request.headers.get('Origin')))) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const respond = async (response: Promise<Response>, request: Request): Promise<Response> =>
+  withCors(await response, request);
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -38,56 +65,76 @@ export default {
 
     // OAuth routes
     if (request.method === 'POST' && url.pathname === ROUTES.OAUTH_START) {
-      return handleOauthStart(request, env);
+      return respond(handleOauthStart(request, env), request);
     }
     if (request.method === 'GET' && url.pathname === ROUTES.OAUTH_CALLBACK) {
-      return handleOauthCallback(request, env);
+      return respond(handleOauthCallback(request, env), request);
     }
     if (request.method === 'POST' && url.pathname === ROUTES.OAUTH_REVOKE) {
-      return handleOauthRevoke(request, env);
+      return respond(handleOauthRevoke(request, env), request);
     }
 
     // Settings routes
     if (request.method === 'GET' && url.pathname === ROUTES.SETTINGS) {
-      return handleGetSettings(request, env);
+      return respond(handleGetSettings(request, env), request);
     }
     if (request.method === 'PUT' && url.pathname === ROUTES.SETTINGS) {
-      return handleUpdateSettings(request, env);
+      return respond(handleUpdateSettings(request, env), request);
     }
 
     // Spreadsheet/Sheet listing routes
     if (request.method === 'GET' && url.pathname === ROUTES.SPREADSHEETS) {
-      return handleListSpreadsheets(request, env);
+      return respond(handleListSpreadsheets(request, env), request);
     }
     if (
       request.method === 'GET' &&
       url.pathname.startsWith('/integrations/google/spreadsheets/') &&
       url.pathname.endsWith('/sheets')
     ) {
-      return handleListSheets(request, env);
+      return respond(handleListSheets(request, env), request);
     }
 
     // Sync route
     if (request.method === 'POST' && url.pathname === ROUTES.SYNC) {
-      return handleSyncSession(request, env);
+      return respond(handleSyncSession(request, env), request);
     }
 
     if (request.method === 'POST' && url.pathname === ROUTES.SYNC_DELETE) {
-      return handleDeleteSyncedSession(request, env);
+      return respond(handleDeleteSyncedSession(request, env), request);
     }
 
     if (request.method === 'POST' && url.pathname === ROUTES.RUNNING_START) {
-      return handleRunningSessionStart(request, env);
+      return respond(handleRunningSessionStart(request, env), request);
     }
 
     if (request.method === 'PATCH' && url.pathname === ROUTES.RUNNING_UPDATE) {
-      return handleRunningSessionUpdate(request, env);
+      return respond(handleRunningSessionUpdate(request, env), request);
     }
 
     if (request.method === 'POST' && url.pathname === ROUTES.RUNNING_CANCEL) {
-      return handleRunningSessionCancel(request, env);
+      return respond(handleRunningSessionCancel(request, env), request);
     }
 
-    return new Response('Not Found', { status: 404 });
+    if (request.method === 'GET' && url.pathname === ROUTES.TIME_TRACKER_RUNNING) {
+      return respond(handleGetRunningState(request, env), request);
+    }
+
+    if (request.method === 'POST' && url.pathname === ROUTES.TIME_TRACKER_RUNNING_START) {
+      return respond(handleStartRunningSession(request, env), request);
+    }
+
+    if (request.method === 'PATCH' && url.pathname === ROUTES.TIME_TRACKER_RUNNING_UPDATE) {
+      return respond(handleUpdateRunningSession(request, env), request);
+    }
+
+    if (request.method === 'POST' && url.pathname === ROUTES.TIME_TRACKER_RUNNING_STOP) {
+      return respond(handleStopRunningSession(request, env), request);
+    }
+
+    if (request.method === 'POST' && url.pathname === ROUTES.TIME_TRACKER_RUNNING_CANCEL) {
+      return respond(handleCancelRunningSession(request, env), request);
+    }
+
+    return withCors(new Response('Not Found', { status: 404 }), request);
   },
 };

--- a/api/src/repositories/__tests__/googleConnections.test.ts
+++ b/api/src/repositories/__tests__/googleConnections.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { encryptSecret } from '../../security/tokenCrypto';
+import {
+  type GoogleSpreadsheetConnectionRow,
+  getConnectionByUser,
+  updateAccessToken,
+  upsertConnection,
+} from '../googleConnections';
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: 'client-123',
+  GOOGLE_CLIENT_SECRET: 'secret-xyz',
+  GOOGLE_REDIRECT_URI: 'https://worker.example.com/oauth/callback',
+  TOKEN_ENCRYPTION_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+} as const;
+
+const ACCESS_TOKEN_AAD = 'google_spreadsheet_connections.access_token';
+const REFRESH_TOKEN_AAD = 'google_spreadsheet_connections.refresh_token';
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+const connectionRow = (
+  overrides: Partial<GoogleSpreadsheetConnectionRow> = {},
+): GoogleSpreadsheetConnectionRow => ({
+  id: 'conn-1',
+  user_id: 'user-1',
+  google_user_id: 'google-user-1',
+  spreadsheet_id: 'spreadsheet-1',
+  sheet_id: 0,
+  sheet_title: 'Sheet1',
+  access_token: 'access',
+  refresh_token: 'refresh',
+  access_token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  status: 'active',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('google connections repository token handling', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('encrypts Google tokens before storing a connection', async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      const requestBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+      requestBodies.push(requestBody);
+      return jsonResponse([
+        connectionRow({
+          access_token: String(requestBody.access_token),
+          refresh_token: String(requestBody.refresh_token),
+        }),
+      ]);
+    });
+
+    const row = await upsertConnection(env, {
+      userId: 'user-1',
+      googleUserId: 'google-user-1',
+      accessToken: 'google-access-token',
+      refreshToken: 'google-refresh-token',
+      accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+      status: 'active',
+    });
+    const storedBody = requestBodies[0];
+    if (!storedBody) {
+      throw new Error('Missing stored request body');
+    }
+
+    expect(storedBody.access_token).toMatch(/^enc:v1:/u);
+    expect(storedBody.refresh_token).toMatch(/^enc:v1:/u);
+    expect(storedBody.access_token).not.toBe('google-access-token');
+    expect(storedBody.refresh_token).not.toBe('google-refresh-token');
+    expect(row.access_token).toBe('google-access-token');
+    expect(row.refresh_token).toBe('google-refresh-token');
+  });
+
+  it('decrypts encrypted Google tokens when loading a connection', async () => {
+    const accessToken = await encryptSecret(
+      'google-access-token',
+      env.TOKEN_ENCRYPTION_KEY,
+      ACCESS_TOKEN_AAD,
+    );
+    const refreshToken = await encryptSecret(
+      'google-refresh-token',
+      env.TOKEN_ENCRYPTION_KEY,
+      REFRESH_TOKEN_AAD,
+    );
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        connectionRow({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        }),
+      ]),
+    );
+
+    const row = await getConnectionByUser(env, 'user-1');
+
+    expect(row?.access_token).toBe('google-access-token');
+    expect(row?.refresh_token).toBe('google-refresh-token');
+  });
+
+  it('encrypts refreshed access and refresh tokens when patching a connection', async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+      return new Response(null, { status: 204 });
+    });
+
+    await updateAccessToken(
+      env,
+      'conn-1',
+      'new-google-access-token',
+      new Date(Date.now() + 3600_000).toISOString(),
+      'existing-google-refresh-token',
+    );
+
+    const storedBody = requestBodies[0];
+    if (!storedBody) {
+      throw new Error('Missing stored request body');
+    }
+
+    expect(storedBody.access_token).toMatch(/^enc:v1:/u);
+    expect(storedBody.refresh_token).toMatch(/^enc:v1:/u);
+    expect(storedBody.access_token).not.toBe('new-google-access-token');
+    expect(storedBody.refresh_token).not.toBe('existing-google-refresh-token');
+  });
+
+  it('keeps legacy plaintext rows readable during migration', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        connectionRow({
+          access_token: 'legacy-access-token',
+          refresh_token: 'legacy-refresh-token',
+        }),
+      ]),
+    );
+
+    const row = await getConnectionByUser(
+      {
+        ...env,
+        TOKEN_ENCRYPTION_KEY: undefined,
+      },
+      'user-1',
+    );
+
+    expect(row?.access_token).toBe('legacy-access-token');
+    expect(row?.refresh_token).toBe('legacy-refresh-token');
+  });
+});

--- a/api/src/repositories/__tests__/timeTracker.test.ts
+++ b/api/src/repositories/__tests__/timeTracker.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRunningState, insertSession, upsertRunningState } from '../timeTracker';
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: '',
+  GOOGLE_CLIENT_SECRET: '',
+  GOOGLE_REDIRECT_URI: '',
+} as const;
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+describe('time tracker Supabase repository', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('loads running state with an explicit verified-user filter', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          status: 'running',
+          elapsed_seconds: 5,
+          draft: {
+            id: 'session-1',
+            title: 'Focus',
+            startedAt: '2026-04-30T00:00:00.000Z',
+          },
+        },
+      ]),
+    );
+
+    const state = await getRunningState(env, 'user-1');
+
+    expect(state).toEqual({
+      status: 'running',
+      draft: {
+        id: 'session-1',
+        title: 'Focus',
+        startedAt: '2026-04-30T00:00:00.000Z',
+      },
+      elapsedSeconds: 5,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(parsedUrl.pathname).toBe('/rest/v1/time_tracker_running_states');
+    expect(parsedUrl.searchParams.get('user_id')).toBe('eq.user-1');
+    expect(parsedUrl.searchParams.get('select')).toBe('status,elapsed_seconds,draft');
+    expect(init).toMatchObject({ method: 'GET' });
+  });
+
+  it('upserts running state with user_id derived from the verified user', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          status: 'running',
+          elapsed_seconds: 0,
+          draft: {
+            id: 'session-1',
+            title: 'Focus',
+            startedAt: '2026-04-30T00:00:00.000Z',
+          },
+        },
+      ]),
+    );
+
+    await upsertRunningState(env, 'user-1', {
+      status: 'running',
+      draft: {
+        id: 'session-1',
+        title: 'Focus',
+        startedAt: '2026-04-30T00:00:00.000Z',
+      },
+      elapsedSeconds: 0,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(parsedUrl.pathname).toBe('/rest/v1/time_tracker_running_states');
+    expect(parsedUrl.searchParams.get('on_conflict')).toBe('user_id');
+    expect(init).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      user_id: 'user-1',
+      status: 'running',
+      elapsed_seconds: 0,
+    });
+  });
+
+  it('inserts completed sessions with user_id derived from the verified user', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'session-1',
+          title: 'Focus',
+          started_at: '2026-04-30T00:00:00.000Z',
+          ended_at: '2026-04-30T00:05:00.000Z',
+          duration_seconds: 300,
+          project: 'Forge',
+          notes: null,
+          tags: ['mcp'],
+        },
+      ]),
+    );
+
+    await insertSession(env, 'user-1', {
+      id: 'session-1',
+      title: 'Focus',
+      startedAt: '2026-04-30T00:00:00.000Z',
+      endedAt: '2026-04-30T00:05:00.000Z',
+      durationSeconds: 300,
+      project: 'Forge',
+      tags: ['mcp'],
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(parsedUrl.pathname).toBe('/rest/v1/time_tracker_sessions');
+    expect(parsedUrl.searchParams.get('on_conflict')).toBeNull();
+    expect(init).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      id: 'session-1',
+      user_id: 'user-1',
+      title: 'Focus',
+      started_at: '2026-04-30T00:00:00.000Z',
+      ended_at: '2026-04-30T00:05:00.000Z',
+      duration_seconds: 300,
+      project: 'Forge',
+    });
+  });
+});

--- a/api/src/repositories/googleConnections.ts
+++ b/api/src/repositories/googleConnections.ts
@@ -1,4 +1,5 @@
 import type { Env } from '../env';
+import { decryptSecret, encryptSecret } from '../security/tokenCrypto';
 
 export type ConnectionStatus = 'active' | 'revoked' | 'error';
 
@@ -89,6 +90,8 @@ export class SupabaseRepositoryError extends Error {
 }
 
 const REST_PREFIX = '/rest/v1';
+const ACCESS_TOKEN_AAD = 'google_spreadsheet_connections.access_token';
+const REFRESH_TOKEN_AAD = 'google_spreadsheet_connections.refresh_token';
 
 const ensureConfig = (env: Env) => {
   if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
@@ -182,7 +185,20 @@ export const getConnectionByUser = async (
       },
     },
   );
-  return records.length > 0 ? records[0] : null;
+  if (records.length === 0) {
+    return null;
+  }
+
+  const row = records[0];
+  return {
+    ...row,
+    access_token: await decryptSecret(row.access_token, env.TOKEN_ENCRYPTION_KEY, ACCESS_TOKEN_AAD),
+    refresh_token: await decryptSecret(
+      row.refresh_token,
+      env.TOKEN_ENCRYPTION_KEY,
+      REFRESH_TOKEN_AAD,
+    ),
+  };
 };
 
 export const upsertConnection = async (
@@ -192,8 +208,16 @@ export const upsertConnection = async (
   const body = {
     user_id: payload.userId,
     google_user_id: payload.googleUserId,
-    access_token: payload.accessToken,
-    refresh_token: payload.refreshToken,
+    access_token: await encryptSecret(
+      payload.accessToken,
+      env.TOKEN_ENCRYPTION_KEY,
+      ACCESS_TOKEN_AAD,
+    ),
+    refresh_token: await encryptSecret(
+      payload.refreshToken,
+      env.TOKEN_ENCRYPTION_KEY,
+      REFRESH_TOKEN_AAD,
+    ),
     access_token_expires_at: payload.accessTokenExpiresAt,
     scopes: payload.scopes ?? ['https://www.googleapis.com/auth/spreadsheets'],
     status: payload.status ?? 'active',
@@ -211,7 +235,16 @@ export const upsertConnection = async (
     },
   );
 
-  return rows[0];
+  const row = rows[0];
+  return {
+    ...row,
+    access_token: await decryptSecret(row.access_token, env.TOKEN_ENCRYPTION_KEY, ACCESS_TOKEN_AAD),
+    refresh_token: await decryptSecret(
+      row.refresh_token,
+      env.TOKEN_ENCRYPTION_KEY,
+      REFRESH_TOKEN_AAD,
+    ),
+  };
 };
 
 export const updateAccessToken = async (
@@ -219,14 +252,24 @@ export const updateAccessToken = async (
   connectionId: string,
   accessToken: string,
   expiresAt: string,
+  refreshToken?: string,
 ): Promise<void> => {
+  const body: Record<string, unknown> = {
+    access_token: await encryptSecret(accessToken, env.TOKEN_ENCRYPTION_KEY, ACCESS_TOKEN_AAD),
+    access_token_expires_at: expiresAt,
+    updated_at: new Date().toISOString(),
+  };
+  if (refreshToken !== undefined) {
+    body.refresh_token = await encryptSecret(
+      refreshToken,
+      env.TOKEN_ENCRYPTION_KEY,
+      REFRESH_TOKEN_AAD,
+    );
+  }
+
   await request(env, 'PATCH', 'google_spreadsheet_connections', {
     searchParams: { id: `eq.${connectionId}` },
-    body: {
-      access_token: accessToken,
-      access_token_expires_at: expiresAt,
-      updated_at: new Date().toISOString(),
-    },
+    body,
   });
 };
 

--- a/api/src/repositories/timeTracker.ts
+++ b/api/src/repositories/timeTracker.ts
@@ -1,0 +1,206 @@
+import type { Env } from '../env';
+import type { RunningSessionStatePayload, TimeTrackerSessionPayload } from '../types';
+
+type RunningStateRow = {
+  status: 'idle' | 'running';
+  elapsed_seconds: number | null;
+  draft: RunningSessionStatePayload['draft'] | null;
+};
+
+type SessionRow = {
+  id: string;
+  title: string;
+  started_at: string;
+  ended_at: string;
+  duration_seconds: number | null;
+  tags: string[] | null;
+  project: string | null;
+  notes: string | null;
+};
+
+export class TimeTrackerRepositoryError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'TimeTrackerRepositoryError';
+    this.status = status;
+  }
+}
+
+const REST_PREFIX = '/rest/v1';
+
+const ensureConfig = (env: Env) => {
+  if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new TimeTrackerRepositoryError('Supabase REST configuration is missing', 500);
+  }
+};
+
+const resolveRestUrl = (env: Env, path: string, searchParams?: Record<string, string>): URL => {
+  const url = new URL(`${REST_PREFIX}/${path}`, env.SUPABASE_URL);
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url;
+};
+
+const restHeaders = (env: Env, prefer?: string): HeadersInit => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+    apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+    'Content-Type': 'application/json',
+  };
+  if (prefer) {
+    headers.Prefer = prefer;
+  }
+  return headers;
+};
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+  const text = await response.text();
+  return text as unknown as T;
+};
+
+const request = async <T>(
+  env: Env,
+  method: string,
+  path: string,
+  options: {
+    searchParams?: Record<string, string>;
+    body?: unknown;
+    prefer?: string;
+  } = {},
+): Promise<T> => {
+  ensureConfig(env);
+  const url = resolveRestUrl(env, path, options.searchParams);
+  const response = await fetch(url, {
+    method,
+    headers: restHeaders(env, options.prefer),
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    let detail: unknown;
+    try {
+      detail = await response.json();
+    } catch {
+      detail = await response.text();
+    }
+    throw new TimeTrackerRepositoryError(
+      `Supabase request failed: ${method} ${url.toString()} (${response.status}) ${JSON.stringify(
+        detail,
+      )}`,
+      response.status,
+    );
+  }
+
+  return handleResponse<T>(response);
+};
+
+const mapRunningStateRow = (row: RunningStateRow): RunningSessionStatePayload => {
+  if (row.status !== 'running' || !row.draft) {
+    return { status: 'idle', draft: null, elapsedSeconds: 0 };
+  }
+
+  return {
+    status: 'running',
+    draft: row.draft,
+    elapsedSeconds: row.elapsed_seconds ?? 0,
+  };
+};
+
+const mapSessionRow = (row: SessionRow): TimeTrackerSessionPayload => {
+  const session: TimeTrackerSessionPayload = {
+    id: row.id,
+    title: row.title,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    durationSeconds: row.duration_seconds ?? 0,
+  };
+
+  if (Array.isArray(row.tags) && row.tags.length > 0) {
+    session.tags = row.tags;
+  }
+  if (row.project) {
+    session.project = row.project;
+  }
+  if (row.notes) {
+    session.notes = row.notes;
+  }
+
+  return session;
+};
+
+export const getRunningState = async (
+  env: Env,
+  userId: string,
+): Promise<RunningSessionStatePayload | null> => {
+  const rows = await request<RunningStateRow[]>(env, 'GET', 'time_tracker_running_states', {
+    searchParams: {
+      select: 'status,elapsed_seconds,draft',
+      user_id: `eq.${userId}`,
+      limit: '1',
+    },
+  });
+
+  return rows.length > 0 ? mapRunningStateRow(rows[0]) : null;
+};
+
+export const upsertRunningState = async (
+  env: Env,
+  userId: string,
+  state: RunningSessionStatePayload,
+): Promise<RunningSessionStatePayload> => {
+  const rows = await request<RunningStateRow[]>(env, 'POST', 'time_tracker_running_states', {
+    body: {
+      user_id: userId,
+      status: state.status,
+      elapsed_seconds: state.elapsedSeconds,
+      draft: state.status === 'running' ? state.draft : null,
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: {
+      on_conflict: 'user_id',
+      select: 'status,elapsed_seconds,draft',
+    },
+    prefer: 'resolution=merge-duplicates,return=representation',
+  });
+
+  return mapRunningStateRow(rows[0]);
+};
+
+export const insertSession = async (
+  env: Env,
+  userId: string,
+  session: TimeTrackerSessionPayload,
+): Promise<TimeTrackerSessionPayload> => {
+  const rows = await request<SessionRow[]>(env, 'POST', 'time_tracker_sessions', {
+    body: {
+      id: session.id,
+      user_id: userId,
+      title: session.title,
+      started_at: session.startedAt,
+      ended_at: session.endedAt,
+      duration_seconds: session.durationSeconds,
+      tags: session.tags && session.tags.length > 0 ? session.tags : null,
+      project: session.project ?? null,
+      notes: session.notes ?? null,
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: {
+      select: 'id,title,started_at,ended_at,duration_seconds,tags,project,notes',
+    },
+    prefer: 'return=representation',
+  });
+
+  return mapSessionRow(rows[0]);
+};

--- a/api/src/security/__tests__/tokenCrypto.test.ts
+++ b/api/src/security/__tests__/tokenCrypto.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { decryptSecret, encryptSecret, isEncryptedSecret } from '../tokenCrypto';
+
+const key = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+
+describe('tokenCrypto', () => {
+  it('encrypts and decrypts a secret with authenticated associated data', async () => {
+    const encrypted = await encryptSecret(
+      'google-refresh-token',
+      key,
+      'google_spreadsheet_connections.refresh_token',
+    );
+
+    expect(isEncryptedSecret(encrypted)).toBe(true);
+    expect(encrypted).not.toContain('google-refresh-token');
+    await expect(
+      decryptSecret(encrypted, key, 'google_spreadsheet_connections.refresh_token'),
+    ).resolves.toBe('google-refresh-token');
+  });
+
+  it('rejects ciphertext when associated data does not match', async () => {
+    const encrypted = await encryptSecret(
+      'google-refresh-token',
+      key,
+      'google_spreadsheet_connections.refresh_token',
+    );
+
+    await expect(
+      decryptSecret(encrypted, key, 'google_spreadsheet_connections.access_token'),
+    ).rejects.toThrow();
+  });
+
+  it('passes legacy plaintext through unchanged', async () => {
+    await expect(decryptSecret('legacy-refresh-token', undefined, 'aad')).resolves.toBe(
+      'legacy-refresh-token',
+    );
+  });
+
+  it('requires configured key material for new encrypted writes', async () => {
+    await expect(encryptSecret('secret', undefined, 'aad')).rejects.toThrow(
+      'TOKEN_ENCRYPTION_KEY is required',
+    );
+  });
+});

--- a/api/src/security/tokenCrypto.ts
+++ b/api/src/security/tokenCrypto.ts
@@ -1,0 +1,114 @@
+const ENCRYPTED_SECRET_PREFIX = 'enc:v1';
+const AES_GCM_IV_BYTES = 12;
+const AES_256_KEY_BYTES = 32;
+
+export class TokenCryptoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TokenCryptoError';
+  }
+}
+
+const bytesToBase64Url = (bytes: Uint8Array): string => {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+};
+
+const base64UrlToBytes = (value: string): Uint8Array => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+};
+
+const hexToBytes = (value: string): Uint8Array => {
+  const bytes = new Uint8Array(value.length / 2);
+  for (let index = 0; index < value.length; index += 2) {
+    bytes[index / 2] = Number.parseInt(value.slice(index, index + 2), 16);
+  }
+  return bytes;
+};
+
+const decodeKeyMaterial = (keyMaterial: string | undefined): Uint8Array => {
+  if (!keyMaterial || keyMaterial.trim().length === 0) {
+    throw new TokenCryptoError('TOKEN_ENCRYPTION_KEY is required');
+  }
+
+  const trimmed = keyMaterial.trim();
+  const bytes = /^[0-9a-f]{64}$/iu.test(trimmed) ? hexToBytes(trimmed) : base64UrlToBytes(trimmed);
+  if (bytes.byteLength !== AES_256_KEY_BYTES) {
+    throw new TokenCryptoError('TOKEN_ENCRYPTION_KEY must decode to 32 bytes');
+  }
+  return bytes;
+};
+
+const importAesKey = async (keyMaterial: string | undefined): Promise<CryptoKey> => {
+  const keyBytes = decodeKeyMaterial(keyMaterial);
+  return crypto.subtle.importKey('raw', keyBytes, 'AES-GCM', false, ['encrypt', 'decrypt']);
+};
+
+const aadBytes = (associatedData: string): Uint8Array => new TextEncoder().encode(associatedData);
+
+export const isEncryptedSecret = (value: string): boolean =>
+  value.startsWith(`${ENCRYPTED_SECRET_PREFIX}:`);
+
+export const encryptSecret = async (
+  plaintext: string,
+  keyMaterial: string | undefined,
+  associatedData: string,
+): Promise<string> => {
+  if (plaintext.length === 0) {
+    return plaintext;
+  }
+
+  const key = await importAesKey(keyMaterial);
+  const iv = new Uint8Array(AES_GCM_IV_BYTES);
+  crypto.getRandomValues(iv);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv,
+      additionalData: aadBytes(associatedData),
+    },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+
+  return [
+    ENCRYPTED_SECRET_PREFIX,
+    bytesToBase64Url(iv),
+    bytesToBase64Url(new Uint8Array(ciphertext)),
+  ].join(':');
+};
+
+export const decryptSecret = async (
+  value: string,
+  keyMaterial: string | undefined,
+  associatedData: string,
+): Promise<string> => {
+  if (value.length === 0 || !isEncryptedSecret(value)) {
+    return value;
+  }
+
+  const [, version, ivValue, ciphertextValue] = value.split(':');
+  if (version !== 'v1' || !ivValue || !ciphertextValue) {
+    throw new TokenCryptoError('Encrypted token payload is malformed');
+  }
+
+  const key = await importAesKey(keyMaterial);
+  const plaintext = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: base64UrlToBytes(ivValue),
+      additionalData: aadBytes(associatedData),
+    },
+    key,
+    base64UrlToBytes(ciphertextValue),
+  );
+
+  return new TextDecoder().decode(plaintext);
+};

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -74,7 +74,37 @@ export type RunningSessionUpdateRequest = {
 };
 
 export type RunningSessionCancelRequest = {
+  id?: string;
+};
+
+export type RunningSessionStatePayload =
+  | {
+      status: 'idle';
+      draft: null;
+      elapsedSeconds: 0;
+    }
+  | {
+      status: 'running';
+      draft: RunningSessionDraftPayload;
+      elapsedSeconds: number;
+    };
+
+export type RunningSessionStopRequest = {
+  id?: string;
+  stoppedAt?: string | number;
+};
+
+export type TimeTrackerSessionPayload = {
   id: string;
+  title: string;
+  startedAt: string;
+  endedAt: string;
+  durationSeconds: number;
+  project?: string | null;
+  notes?: string | null;
+  tags?: string[];
+  skill?: string | null;
+  intensity?: string | null;
 };
 
 export type ColumnMappingConfig = {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types", "vitest/globals"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/docs/specs/time-tracker-worker-api/plan.md
+++ b/docs/specs/time-tracker-worker-api/plan.md
@@ -1,0 +1,41 @@
+# Time Tracker Worker API / MCP Verification Plan
+
+## Scope
+
+ブラウザと MCP の両方が最終的に同じ Cloudflare Worker API を使えるようにする。今回の実装はローカル差分だけで進め、Cloudflare / Supabase / Google / GitHub への deploy、apply、migration、token 発行、push は行わない。
+
+## Task slices
+
+1. Verification foundation
+   - Worker handler tests を先に追加し、Supabase / Google / Cloudflare への実通信を `vi.fn` で遮断する。
+   - Repository tests で Supabase REST の URL と body を検査し、`user_id` は認証済み user id からのみ入ることを確認する。
+   - Static guard tests で service role key が app 側へ露出しないこと、time-tracker handler が request body の `user_id` / `userId` を参照しないことを確認する。
+2. Canonical Worker API
+   - `GET /time-tracker/running`
+   - `POST /time-tracker/running/start`
+   - `PATCH /time-tracker/running/update`
+   - `POST /time-tracker/running/stop`
+   - `POST /time-tracker/running/cancel`
+   - すべて Supabase JWT で認証し、Worker は verified user id だけを使って Supabase REST を呼ぶ。
+3. Browser migration
+   - 既存 app の direct Supabase write を Worker API に移すかは別 slice で判断する。
+   - 移行する場合も dual-write divergence を避け、Supabase canonical state と Sheets sync の順序をテストする。
+4. MCP auth
+   - local MCP は Forge scoped token を候補にする。Supabase refresh token、service role key、Google refresh token は MCP に渡さない。
+   - remote MCP は OAuth-compatible flow を別 slice で検討する。
+5. Cloudflare IaC
+   - Pulumi / Terraform の候補はローカル設計または scaffold まで。`pulumi up` / `terraform apply` / `wrangler deploy` は明日の同席確認まで禁止。
+
+## Local verification commands
+
+- `pnpm --filter api test:run`
+- `pnpm --filter api lint`
+- `pnpm format:check`
+- Workspace 側の governance 変更後は `bun run ai:verify`
+
+## Deferred paired checks
+
+- Cloudflare Worker vars / secrets / routes / CORS origin
+- Supabase service role secret rotation and RLS bypass boundary
+- Google OAuth redirect URI and token storage policy
+- GitHub branch / PR publication


### PR DESCRIPTION
## Summary
- Add canonical Cloudflare Worker time-tracker API for running session start/update/stop/cancel
- Harden Google OAuth state with HMAC signature, 10 minute expiry, and app-relative redirect validation
- Encrypt stored Google access/refresh tokens with AES-GCM via TOKEN_ENCRYPTION_KEY, while keeping legacy plaintext rows readable during migration
- Restrict CORS fallback and add static security boundary tests

## Deployment
- Deployed manually to Cloudflare Worker forge-api before this PR
- Deployed version: 9d0bb598-1e7e-4073-bfaf-bf20605061cb
- Added Worker secrets before release: OAUTH_STATE_SIGNING_SECRET, TOKEN_ENCRYPTION_KEY

## Verification
- pnpm format:check
- pnpm lint
- pnpm --filter api test:run
- pnpm --filter api exec tsc --noEmit -p tsconfig.json
- bun run ai:verify

## Notes
- Existing plaintext Google token rows remain readable temporarily; they are rewritten as encrypted values on reconnect or token refresh.
- No Supabase migration was applied in this slice.