### PR TITLE
fix: repair Google OAuth reconnect flow

### DIFF
--- a/api/src/handlers/__tests__/oauth.test.ts
+++ b/api/src/handlers/__tests__/oauth.test.ts
@@ -53,10 +53,17 @@ const extractStateFromStartResponse = async (response: Response): Promise<string
 
 const decodeSignedStatePayload = (
   state: string,
-): { userId: string; redirectPath: string; nonce: string; exp: number } => {
+): {
+  userId: string;
+  redirectOrigin: string;
+  redirectPath: string;
+  nonce: string;
+  exp: number;
+} => {
   const [encodedPayload] = state.split('.');
   return JSON.parse(Buffer.from(encodedPayload ?? '', 'base64url').toString('utf8')) as {
     userId: string;
+    redirectOrigin: string;
     redirectPath: string;
     nonce: string;
     exp: number;
@@ -154,6 +161,7 @@ describe('oauth handlers', () => {
       expect(state?.split('.')).toHaveLength(2);
       const decoded = decodeSignedStatePayload(state ?? '');
       expect(decoded.userId).toBe('user-1');
+      expect(decoded.redirectOrigin).toBe('https://forge.h031203yama.workers.dev');
       expect(decoded.redirectPath).toBe('/app/dashboard');
       expect(typeof decoded.nonce).toBe('string');
       expect(decoded.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
@@ -239,7 +247,49 @@ describe('oauth handlers', () => {
         }),
       );
       expect(response.status).toBe(302);
-      expect(response.headers.get('Location')).toContain('/app/dashboard');
+      expect(response.headers.get('Location')).toBe(
+        'https://forge.h031203yama.workers.dev/app/dashboard',
+      );
+    });
+
+    it('redirects back to the allowed app origin from the signed state', async () => {
+      mocks.verifySupabaseJwt.mockResolvedValue({ userId: 'user-1', raw: {} });
+      const startResponse = await handleOauthStart(
+        buildRequest('https://example.com/integrations/google/oauth/start', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token-123',
+            'Content-Type': 'application/json',
+            Origin: 'http://localhost:5173',
+          },
+          body: { redirectPath: '/settings?tab=google#connect' },
+        }),
+        env,
+      );
+      const state = await extractStateFromStartResponse(startResponse);
+
+      const tokenResponse = {
+        access_token: 'google-access',
+        refresh_token: 'google-refresh',
+        expires_in: 3600,
+        scope: 'https://www.googleapis.com/auth/spreadsheets',
+        token_type: 'Bearer',
+      };
+      (fetch as unknown as Mock).mockResolvedValue(
+        new Response(JSON.stringify(tokenResponse), { status: 200 }),
+      );
+
+      const response = await handleOauthCallback(
+        buildRequest(
+          `https://example.com/integrations/google/oauth/callback?code=auth-code&state=${state}`,
+        ),
+        env,
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe(
+        'http://localhost:5173/settings?tab=google#connect',
+      );
     });
 
     it('rejects tampered state before exchanging the authorization code', async () => {

--- a/api/src/handlers/oauth.ts
+++ b/api/src/handlers/oauth.ts
@@ -4,7 +4,13 @@ import {
   verifySupabaseJwt,
 } from '../auth/verifySupabaseJwt';
 import type { Env } from '../env';
-import { badRequest, jsonResponse, serverError, unauthorized } from '../http/response';
+import {
+  badRequest,
+  jsonResponse,
+  resolveAllowedOrigin,
+  serverError,
+  unauthorized,
+} from '../http/response';
 import {
   getConnectionByUser,
   SupabaseRepositoryError,
@@ -14,6 +20,7 @@ import {
 
 type OauthStatePayload = {
   userId: string;
+  redirectOrigin: string;
   redirectPath: string;
   nonce: string;
 };
@@ -155,6 +162,9 @@ const decodeState = async (value: string, env: Env): Promise<OauthStatePayload> 
     }
     return {
       userId: parsed.userId,
+      redirectOrigin: resolveAllowedOrigin(
+        typeof parsed.redirectOrigin === 'string' ? parsed.redirectOrigin : null,
+      ),
       redirectPath: parsed.redirectPath,
       nonce: parsed.nonce,
     };
@@ -366,6 +376,7 @@ export const handleOauthStart = async (request: Request, env: Env): Promise<Resp
 
   const state: OauthStatePayload = {
     userId: auth.userId,
+    redirectOrigin: resolveAllowedOrigin(origin),
     redirectPath,
     nonce: buildNonce(),
   };
@@ -474,7 +485,7 @@ export const handleOauthCallback = async (request: Request, env: Env): Promise<R
   return new Response(null, {
     status: 302,
     headers: {
-      Location: state.redirectPath,
+      Location: new URL(state.redirectPath, state.redirectOrigin).toString(),
     },
   });
 };

--- a/api/src/http/response.ts
+++ b/api/src/http/response.ts
@@ -62,4 +62,5 @@ export {
   serverError,
   handleOptions,
   getCorsHeaders,
+  resolveAllowedOrigin,
 };

--- a/app/src/features/settings/components/GoogleSpreadsheetSettingsSection/GoogleSpreadsheetSettingsSection.tsx
+++ b/app/src/features/settings/components/GoogleSpreadsheetSettingsSection/GoogleSpreadsheetSettingsSection.tsx
@@ -36,7 +36,7 @@ export type GoogleSpreadsheetSettingsSectionProps = {
   currentSheetId?: number;
   currentColumnMapping?: ColumnMapping;
   onSave: (selection: SavePayload) => void | Promise<void>;
-  onStartOAuth: () => void;
+  onStartOAuth: () => void | Promise<void>;
   onFetchSpreadsheets: (query?: string) => Promise<FetchSpreadsheetsResult>;
   onFetchSheets: (spreadsheetId: string) => Promise<FetchSheetsResult>;
   isSaving?: boolean;
@@ -44,6 +44,18 @@ export type GoogleSpreadsheetSettingsSectionProps = {
 
 const REAUTH_MESSAGE =
   'Google アカウントとの連携が期限切れになりました。再度連携を行ってください。';
+
+const isReconnectRequiredError = (error: unknown): boolean => {
+  if (!(error instanceof GoogleSyncClientError)) {
+    return false;
+  }
+  if (error.status === 401) {
+    return true;
+  }
+
+  const detail = typeof error.detail === 'string' ? error.detail : JSON.stringify(error.detail);
+  return /invalid_grant|expired or revoked/i.test(`${error.message} ${detail}`);
+};
 
 export const GoogleSpreadsheetSettingsSection: React.FC<GoogleSpreadsheetSettingsSectionProps> = ({
   isConnected,
@@ -69,9 +81,10 @@ export const GoogleSpreadsheetSettingsSection: React.FC<GoogleSpreadsheetSetting
   const [isLoadingSheets, setIsLoadingSheets] = useState(false);
   const [needsReconnect, setNeedsReconnect] = useState(false);
   const [reconnectMessage, setReconnectMessage] = useState<string | null>(null);
+  const [isStartingOAuth, setIsStartingOAuth] = useState(false);
 
   const handleAuthError = useCallback((error: unknown): boolean => {
-    if (error instanceof GoogleSyncClientError && error.status === 401) {
+    if (isReconnectRequiredError(error)) {
       setNeedsReconnect(true);
       setReconnectMessage(REAUTH_MESSAGE);
       setSpreadsheets([]);
@@ -200,6 +213,18 @@ export const GoogleSpreadsheetSettingsSection: React.FC<GoogleSpreadsheetSetting
     });
   };
 
+  const handleStartOAuth = async () => {
+    if (isStartingOAuth) {
+      return;
+    }
+    setIsStartingOAuth(true);
+    try {
+      await onStartOAuth();
+    } finally {
+      setIsStartingOAuth(false);
+    }
+  };
+
   const saveDisabled = !selectedSpreadsheetId || selectedSheetId === undefined || isSaving;
 
   const showReconnectPrompt = needsReconnect || !isConnected;
@@ -230,10 +255,11 @@ export const GoogleSpreadsheetSettingsSection: React.FC<GoogleSpreadsheetSetting
           <div className="settings-section__actions">
             <button
               type="button"
-              onClick={onStartOAuth}
+              onClick={() => void handleStartOAuth()}
               className="settings-section__primary-button"
+              disabled={isStartingOAuth}
             >
-              {oauthButtonLabel}
+              {isStartingOAuth ? '連携を開始しています...' : oauthButtonLabel}
             </button>
           </div>
         </div>

--- a/app/src/features/settings/components/GoogleSpreadsheetSettingsSection/__tests__/GoogleSpreadsheetSettingsSection.test.tsx
+++ b/app/src/features/settings/components/GoogleSpreadsheetSettingsSection/__tests__/GoogleSpreadsheetSettingsSection.test.tsx
@@ -63,6 +63,27 @@ describe('GoogleSpreadsheetSettingsSection', () => {
     expect(defaultProps.onStartOAuth).toHaveBeenCalledTimes(1);
   });
 
+  it('disables OAuth button while reconnect is starting', async () => {
+    const user = userEvent.setup();
+    const onStartOAuth = vi.fn(() => new Promise<void>(() => {}));
+    render(
+      <GoogleSpreadsheetSettingsSection
+        {...defaultProps}
+        isConnected={false}
+        onStartOAuth={onStartOAuth}
+      />,
+    );
+
+    const oauthButton = screen.getByRole('button', {
+      name: /Google アカウントと連携/i,
+    });
+    await user.click(oauthButton);
+    await user.click(oauthButton);
+
+    expect(onStartOAuth).toHaveBeenCalledTimes(1);
+    expect(oauthButton).toBeDisabled();
+  });
+
   it('loads spreadsheets on mount when connected', async () => {
     render(<GoogleSpreadsheetSettingsSection {...defaultProps} />);
 
@@ -121,6 +142,30 @@ describe('GoogleSpreadsheetSettingsSection', () => {
 
   it('shows reconnect prompt when spreadsheet fetch returns 401', async () => {
     const fetchError = new GoogleSyncClientError('Unauthorized', 401);
+    render(
+      <GoogleSpreadsheetSettingsSection
+        {...defaultProps}
+        onFetchSpreadsheets={vi.fn().mockRejectedValue(fetchError)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Google アカウントとの連携が期限切れになりました。再度連携を行ってください。',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Google アカウントを再連携' })).toBeInTheDocument();
+  });
+
+  it('shows reconnect prompt when Google reports invalid_grant', async () => {
+    const fetchError = new GoogleSyncClientError('Google sync request failed', 500, {
+      error: 'internal_error',
+      message:
+        'Failed to exchange authorization code: 400 {"error":"invalid_grant","error_description":"Token has been expired or revoked."}',
+    });
     render(
       <GoogleSpreadsheetSettingsSection
         {...defaultProps}

--- a/app/src/features/settings/pages/SettingsPage/SettingsPage.tsx
+++ b/app/src/features/settings/pages/SettingsPage/SettingsPage.tsx
@@ -3,6 +3,7 @@ import './SettingsPage.css';
 import { useGoogleSpreadsheetOptions } from '@features/time-tracker/hooks/data/useGoogleSpreadsheetOptions.ts';
 import { isGoogleSyncEnabled } from '@infra/config';
 import { GoogleSpreadsheetSettingsSection } from '../../components/GoogleSpreadsheetSettingsSection';
+import { buildOAuthRedirectPath } from './oauthRedirectPath.ts';
 
 type FeedbackState = {
   type: 'success' | 'error';
@@ -37,8 +38,9 @@ export function SettingsPage(): JSX.Element {
   const handleStartOAuth = useCallback(async () => {
     setFeedback(null);
     try {
-      const currentUrl = typeof window !== 'undefined' ? window.location.href : '/settings';
-      const response = await startOAuth(currentUrl);
+      const redirectPath =
+        typeof window !== 'undefined' ? buildOAuthRedirectPath(window.location) : '/settings';
+      const response = await startOAuth(redirectPath);
       if (response.authorizationUrl && typeof window !== 'undefined') {
         window.location.href = response.authorizationUrl;
       }

--- a/app/src/features/settings/pages/SettingsPage/oauthRedirectPath.test.ts
+++ b/app/src/features/settings/pages/SettingsPage/oauthRedirectPath.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildOAuthRedirectPath } from './oauthRedirectPath.ts';
+
+describe('buildOAuthRedirectPath', () => {
+  it('keeps only the app-relative path, query, and hash', () => {
+    expect(
+      buildOAuthRedirectPath({
+        pathname: '/settings',
+        search: '?tab=google',
+        hash: '#connect',
+      }),
+    ).toBe('/settings?tab=google#connect');
+  });
+
+  it('falls back to settings when pathname is malformed', () => {
+    expect(
+      buildOAuthRedirectPath({
+        pathname: 'https://evil.example/settings',
+        search: '',
+        hash: '',
+      }),
+    ).toBe('/settings');
+  });
+});

--- a/app/src/features/settings/pages/SettingsPage/oauthRedirectPath.ts
+++ b/app/src/features/settings/pages/SettingsPage/oauthRedirectPath.ts
@@ -1,0 +1,6 @@
+export const buildOAuthRedirectPath = (
+  location: Pick<Location, 'pathname' | 'search' | 'hash'>,
+): string => {
+  const pathname = location.pathname.startsWith('/') ? location.pathname : '/settings';
+  return `${pathname}${location.search}${location.hash}`;
+};


### PR DESCRIPTION
## Summary
- keep Google OAuth redirect targets app-relative on the frontend
- store the allowed frontend origin in signed OAuth state and redirect callbacks back to that origin
- treat invalid_grant refresh failures as reconnect-required in settings UI and disable the OAuth button while starting

## Verification
- pnpm format:check
- pnpm lint
- pnpm --filter api test:run
- pnpm --filter api exec tsc --noEmit -p tsconfig.json
- pnpm --filter forge-app test:run
- pnpm --filter forge-app build
- pnpm run supply-chain:check
- bun run ai:verify