### PR TITLE
feat(api): sync stopped sessions to Google Sheets

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -32,10 +32,10 @@ Time Trackerの本体状態とGoogle Spreadsheets同期を扱うCloudflare Worke
 - `GET /time-tracker/running` - 実行中セッション状態を取得
 - `POST /time-tracker/running/start` - 実行中セッションを開始
 - `PATCH /time-tracker/running/update` - 実行中セッションの下書き・経過秒数を更新
-- `POST /time-tracker/running/stop` - 実行中セッションを完了セッションとして保存し、実行中状態を解除
+- `POST /time-tracker/running/stop` - 実行中セッションを完了セッションとして保存し、実行中状態を解除したうえでGoogle Sheets同期を試行
 - `POST /time-tracker/running/cancel` - 実行中状態をキャンセル
 
-現時点の Time Tracker 本体APIはSupabaseのcanonical stateを更新します。Google Sheetsへの同期統合とフロントエンド移行は別sliceで扱います。
+Time Tracker 本体APIはSupabaseのcanonical stateを更新します。`stop` はSupabaseへの完了セッション保存を成功条件とし、Google Sheets同期結果は `sync.status` (`success` / `skipped` / `failed`) としてレスポンスに含めます。Sheets同期失敗時もSupabaseの記録はロールバックしません。
 
 ## ローカル開発
 

--- a/api/src/handlers/__tests__/timeTracker.test.ts
+++ b/api/src/handlers/__tests__/timeTracker.test.ts
@@ -12,11 +12,13 @@ const mocks = vi.hoisted(() => {
   const getRunningState = vi.fn();
   const upsertRunningState = vi.fn();
   const insertSession = vi.fn();
+  const handleSyncSession = vi.fn();
   return {
     verifySupabaseJwt,
     getRunningState,
     upsertRunningState,
     insertSession,
+    handleSyncSession,
   };
 });
 
@@ -35,6 +37,14 @@ vi.mock('../../repositories/timeTracker', async (importOriginal) => {
     getRunningState: mocks.getRunningState,
     upsertRunningState: mocks.upsertRunningState,
     insertSession: mocks.insertSession,
+  };
+});
+
+vi.mock('../syncSession', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../syncSession')>();
+  return {
+    ...actual,
+    handleSyncSession: mocks.handleSyncSession,
   };
 });
 
@@ -84,6 +94,18 @@ describe('time tracker canonical Worker handlers', () => {
       userId: 'user-1',
       raw: {},
     });
+    mocks.handleSyncSession.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'connection_missing',
+          message: 'Google spreadsheet connection not found',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
   });
 
   it('returns idle state when the user has no running row', async () => {
@@ -177,9 +199,114 @@ describe('time tracker canonical Worker handlers', () => {
     await expect(response.json()).resolves.toEqual({
       session: completedSession,
       state: idleState,
+      sync: {
+        status: 'skipped',
+        reason: 'Google spreadsheet connection not found',
+        detail: {
+          error: 'connection_missing',
+          message: 'Google spreadsheet connection not found',
+        },
+      },
     });
     expect(mocks.insertSession).toHaveBeenCalledWith(env, 'user-1', completedSession);
     expect(mocks.upsertRunningState).toHaveBeenCalledWith(env, 'user-1', idleState);
+    expect(mocks.handleSyncSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns Google Sheets sync success when stop sync succeeds', async () => {
+    const stoppedAt = '2026-04-30T00:05:00.000Z';
+    const completedSession = {
+      id: 'session-1',
+      title: 'Focus',
+      startedAt: draft.startedAt,
+      endedAt: stoppedAt,
+      durationSeconds: 300,
+      project: 'Forge',
+      tags: ['mcp'],
+      notes: 'local test',
+    };
+    const syncLog = {
+      id: 'sync-1',
+      sessionId: 'session-1',
+      status: 'success',
+      attemptedAt: '2026-04-30T00:05:01.000Z',
+      retryCount: 0,
+    };
+    mocks.getRunningState.mockResolvedValue(runningState);
+    mocks.insertSession.mockResolvedValue(completedSession);
+    mocks.upsertRunningState.mockResolvedValue(idleState);
+    mocks.handleSyncSession.mockResolvedValue(
+      new Response(JSON.stringify(syncLog), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await handleStopRunningSession(
+      buildRequest('POST', '/time-tracker/running/stop', { id: 'session-1', stoppedAt }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      session: completedSession,
+      state: idleState,
+      sync: {
+        status: 'success',
+        log: syncLog,
+      },
+    });
+    expect(mocks.handleSyncSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+      }),
+      env,
+    );
+  });
+
+  it('keeps the completed session when Google Sheets sync fails', async () => {
+    const stoppedAt = '2026-04-30T00:05:00.000Z';
+    const completedSession = {
+      id: 'session-1',
+      title: 'Focus',
+      startedAt: draft.startedAt,
+      endedAt: stoppedAt,
+      durationSeconds: 300,
+      project: 'Forge',
+      tags: ['mcp'],
+      notes: 'local test',
+    };
+    mocks.getRunningState.mockResolvedValue(runningState);
+    mocks.insertSession.mockResolvedValue(completedSession);
+    mocks.upsertRunningState.mockResolvedValue(idleState);
+    mocks.handleSyncSession.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'internal_error',
+          message: 'Failed to refresh access token',
+        }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await handleStopRunningSession(
+      buildRequest('POST', '/time-tracker/running/stop', { id: 'session-1', stoppedAt }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      session: completedSession,
+      state: idleState,
+      sync: {
+        status: 'failed',
+        statusCode: 401,
+        error: 'Failed to refresh access token',
+      },
+    });
   });
 
   it('cancels the current running session without creating a completed session', async () => {

--- a/api/src/handlers/timeTracker.ts
+++ b/api/src/handlers/timeTracker.ts
@@ -19,6 +19,7 @@ import type {
   RunningSessionUpdateRequest,
   TimeTrackerSessionPayload,
 } from '../types';
+import { handleSyncSession } from './syncSession';
 
 class HttpResponseError extends Error {
   readonly response: Response;
@@ -195,6 +196,112 @@ const buildCompletedSession = (
   return session;
 };
 
+type CompletedSessionSyncResult =
+  | {
+      status: 'success';
+      log: unknown;
+    }
+  | {
+      status: 'skipped';
+      reason: string;
+      detail?: unknown;
+    }
+  | {
+      status: 'failed';
+      statusCode: number;
+      error: string;
+      detail?: unknown;
+    };
+
+const skippedSyncErrors = new Set([
+  'connection_missing',
+  'connection_inactive',
+  'selection_missing',
+  'mapping_missing',
+  'mapping_incomplete',
+]);
+
+const readResponseBody = async (response: Response): Promise<unknown> => {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+};
+
+const describeSyncError = (detail: unknown, fallback: string): string => {
+  if (detail && typeof detail === 'object' && 'message' in detail) {
+    const message = (detail as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+  }
+  if (typeof detail === 'string' && detail.trim().length > 0) {
+    return detail;
+  }
+  return fallback;
+};
+
+const syncCompletedSession = async (
+  request: Request,
+  env: Env,
+  session: TimeTrackerSessionPayload,
+): Promise<CompletedSessionSyncResult> => {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return { status: 'skipped', reason: 'Bearer token is required' };
+  }
+
+  try {
+    const syncUrl = new URL('/integrations/google/sync', request.url);
+    const syncResponse = await handleSyncSession(
+      new Request(syncUrl.toString(), {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          session,
+          source: 'time-tracker-worker-api',
+        }),
+      }),
+      env,
+    );
+    const detail = await readResponseBody(syncResponse);
+
+    if (syncResponse.ok) {
+      return { status: 'success', log: detail };
+    }
+
+    const errorCode =
+      detail && typeof detail === 'object' && 'error' in detail
+        ? (detail as { error?: unknown }).error
+        : null;
+    const reason = describeSyncError(
+      detail,
+      `Google sync failed with status ${syncResponse.status}`,
+    );
+
+    if (typeof errorCode === 'string' && skippedSyncErrors.has(errorCode)) {
+      return { status: 'skipped', reason, detail };
+    }
+
+    return {
+      status: 'failed',
+      statusCode: syncResponse.status,
+      error: reason,
+      detail,
+    };
+  } catch (error) {
+    return {
+      status: 'failed',
+      statusCode: 500,
+      error: error instanceof Error ? error.message : 'Unknown Google sync error',
+    };
+  }
+};
+
 const handleError = (responseOrError: unknown): Response => {
   if (responseOrError instanceof HttpResponseError) {
     return responseOrError.response;
@@ -282,8 +389,9 @@ export const handleStopRunningSession = async (request: Request, env: Env): Prom
     const session = buildCompletedSession(currentState.draft, stoppedAt);
     const savedSession = await insertSession(env, auth.userId, session);
     const savedState = await upsertRunningState(env, auth.userId, idleState);
+    const sync = await syncCompletedSession(request, env, savedSession);
 
-    return jsonResponse({ session: savedSession, state: savedState });
+    return jsonResponse({ session: savedSession, state: savedState, sync });
   } catch (responseOrError) {
     return handleError(responseOrError);
   }


### PR DESCRIPTION
## Summary
- make POST /time-tracker/running/stop try Google Sheets sync after Supabase persistence succeeds
- keep Supabase as canonical: Sheets sync failure does not roll back the completed session
- return sync.status as success / skipped / failed for MCP and clients to inspect

## Verification
- pnpm format:check
- pnpm lint
- pnpm --filter api exec tsc --noEmit -p tsconfig.json
- pnpm --filter api test:run
- pnpm run supply-chain:check
- bun run ai:verify