### PR TITLE
feat(api): add remote MCP token auth

### DIFF
--- a/api/src/auth/__tests__/mcpTokenAuth.test.ts
+++ b/api/src/auth/__tests__/mcpTokenAuth.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authorizeMcpToken, McpTokenAuthError } from '../mcpTokenAuth';
+
+const mocks = vi.hoisted(() => {
+  const hashMcpToken = vi.fn();
+  const findMcpTokenRecordByHash = vi.fn();
+  const touchMcpTokenRecord = vi.fn();
+  return {
+    hashMcpToken,
+    findMcpTokenRecordByHash,
+    touchMcpTokenRecord,
+  };
+});
+
+vi.mock('../../security/mcpToken', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../security/mcpToken')>();
+  return {
+    ...actual,
+    hashMcpToken: mocks.hashMcpToken,
+  };
+});
+
+vi.mock('../../repositories/mcpTokens', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../repositories/mcpTokens')>();
+  return {
+    ...actual,
+    findMcpTokenRecordByHash: mocks.findMcpTokenRecordByHash,
+    touchMcpTokenRecord: mocks.touchMcpTokenRecord,
+  };
+});
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: '',
+  GOOGLE_CLIENT_SECRET: '',
+  GOOGLE_REDIRECT_URI: '',
+  MCP_TOKEN_HASH_PEPPER: 'pepper',
+} as const;
+
+const buildRequest = (token?: string) =>
+  new Request('https://example.com/mcp', {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+
+const tokenRow = {
+  id: 'token-1',
+  user_id: 'user-1',
+  name: 'Codex',
+  token_hash: 'hash',
+  scopes: ['time-tracker:read', 'time-tracker:write'],
+  expires_at: '2026-08-01T00:00:00.000Z',
+  revoked_at: null,
+  last_used_at: null,
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+} as const;
+
+describe('authorizeMcpToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'));
+    mocks.hashMcpToken.mockResolvedValue('hash');
+    mocks.findMcpTokenRecordByHash.mockResolvedValue(tokenRow);
+    mocks.touchMcpTokenRecord.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('authorizes active MCP tokens with the required scope', async () => {
+    await expect(
+      authorizeMcpToken(buildRequest(`forge_mcp_${'a'.repeat(64)}`), env, 'time-tracker:write'),
+    ).resolves.toEqual({
+      userId: 'user-1',
+      tokenId: 'token-1',
+      scopes: ['time-tracker:read', 'time-tracker:write'],
+    });
+
+    expect(mocks.hashMcpToken).toHaveBeenCalledWith(`forge_mcp_${'a'.repeat(64)}`, 'pepper');
+    expect(mocks.findMcpTokenRecordByHash).toHaveBeenCalledWith(env, 'hash');
+    expect(mocks.touchMcpTokenRecord).toHaveBeenCalledWith(env, 'token-1');
+  });
+
+  it('returns 401 for missing, unknown, revoked, or expired tokens', async () => {
+    await expect(authorizeMcpToken(buildRequest(), env, 'time-tracker:read')).rejects.toMatchObject(
+      { status: 401 },
+    );
+
+    mocks.findMcpTokenRecordByHash.mockResolvedValueOnce(null);
+    await expect(
+      authorizeMcpToken(buildRequest(`forge_mcp_${'a'.repeat(64)}`), env, 'time-tracker:read'),
+    ).rejects.toMatchObject({ status: 401 });
+
+    mocks.findMcpTokenRecordByHash.mockResolvedValueOnce({
+      ...tokenRow,
+      revoked_at: '2026-05-01T00:00:00.000Z',
+    });
+    await expect(
+      authorizeMcpToken(buildRequest(`forge_mcp_${'a'.repeat(64)}`), env, 'time-tracker:read'),
+    ).rejects.toMatchObject({ status: 401 });
+
+    mocks.findMcpTokenRecordByHash.mockResolvedValueOnce({
+      ...tokenRow,
+      expires_at: '2026-04-30T00:00:00.000Z',
+    });
+    await expect(
+      authorizeMcpToken(buildRequest(`forge_mcp_${'a'.repeat(64)}`), env, 'time-tracker:read'),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('returns 403 when the token lacks the required scope', async () => {
+    mocks.findMcpTokenRecordByHash.mockResolvedValueOnce({
+      ...tokenRow,
+      scopes: ['time-tracker:read'],
+    });
+
+    await expect(
+      authorizeMcpToken(buildRequest(`forge_mcp_${'a'.repeat(64)}`), env, 'time-tracker:write'),
+    ).rejects.toEqual(new McpTokenAuthError('Insufficient scope', 403));
+  });
+});

--- a/api/src/auth/mcpTokenAuth.ts
+++ b/api/src/auth/mcpTokenAuth.ts
@@ -1,0 +1,67 @@
+import type { Env } from '../env';
+import {
+  findMcpTokenRecordByHash,
+  type McpTokenScope,
+  touchMcpTokenRecord,
+} from '../repositories/mcpTokens';
+import { hashMcpToken, McpTokenCryptoError } from '../security/mcpToken';
+import { extractBearerToken } from './verifySupabaseJwt';
+
+export type McpTokenAuthResult = {
+  userId: string;
+  tokenId: string;
+  scopes: McpTokenScope[];
+};
+
+export class McpTokenAuthError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'McpTokenAuthError';
+    this.status = status;
+  }
+}
+
+export const authorizeMcpToken = async (
+  request: Request,
+  env: Env,
+  requiredScope: McpTokenScope,
+): Promise<McpTokenAuthResult> => {
+  const token = extractBearerToken(request);
+  if (!token) {
+    throw new McpTokenAuthError('Bearer token is required', 401);
+  }
+
+  let tokenHash: string;
+  try {
+    tokenHash = await hashMcpToken(token, env.MCP_TOKEN_HASH_PEPPER);
+  } catch (error) {
+    if (error instanceof McpTokenCryptoError) {
+      throw new McpTokenAuthError(error.message, error.message.includes('required') ? 500 : 401);
+    }
+    throw new McpTokenAuthError('Invalid token', 401);
+  }
+
+  const record = await findMcpTokenRecordByHash(env, tokenHash);
+  if (!record) {
+    throw new McpTokenAuthError('Invalid token', 401);
+  }
+  if (record.revoked_at) {
+    throw new McpTokenAuthError('Invalid token', 401);
+  }
+  if (new Date(record.expires_at).getTime() <= Date.now()) {
+    throw new McpTokenAuthError('Invalid token', 401);
+  }
+  if (!record.scopes.includes(requiredScope)) {
+    throw new McpTokenAuthError('Insufficient scope', 403);
+  }
+
+  await touchMcpTokenRecord(env, record.id);
+
+  return {
+    userId: record.user_id,
+    tokenId: record.id,
+    scopes: record.scopes,
+  };
+};

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -6,4 +6,5 @@ export interface Env {
   GOOGLE_REDIRECT_URI: string;
   OAUTH_STATE_SIGNING_SECRET?: string;
   TOKEN_ENCRYPTION_KEY?: string;
+  MCP_TOKEN_HASH_PEPPER?: string;
 }

--- a/api/src/handlers/__tests__/mcp.test.ts
+++ b/api/src/handlers/__tests__/mcp.test.ts
@@ -4,15 +4,21 @@ import { handleMcp } from '../mcp';
 const mocks = vi.hoisted(() => {
   const authorizeMcpToken = vi.fn();
   const getRunningStateForUser = vi.fn();
+  const listSessionsForUser = vi.fn();
   const startRunningSessionForUser = vi.fn();
+  const updateRunningSessionForUser = vi.fn();
   const stopRunningSessionForUser = vi.fn();
   const cancelRunningSessionForUser = vi.fn();
+  const recordSessionForUser = vi.fn();
   return {
     authorizeMcpToken,
     getRunningStateForUser,
+    listSessionsForUser,
     startRunningSessionForUser,
+    updateRunningSessionForUser,
     stopRunningSessionForUser,
     cancelRunningSessionForUser,
+    recordSessionForUser,
   };
 });
 
@@ -29,9 +35,12 @@ vi.mock('../timeTracker', async (importOriginal) => {
   return {
     ...actual,
     getRunningStateForUser: mocks.getRunningStateForUser,
+    listSessionsForUser: mocks.listSessionsForUser,
     startRunningSessionForUser: mocks.startRunningSessionForUser,
+    updateRunningSessionForUser: mocks.updateRunningSessionForUser,
     stopRunningSessionForUser: mocks.stopRunningSessionForUser,
     cancelRunningSessionForUser: mocks.cancelRunningSessionForUser,
+    recordSessionForUser: mocks.recordSessionForUser,
   };
 });
 
@@ -99,8 +108,11 @@ describe('remote HTTP MCP handler', () => {
         tools: expect.arrayContaining([
           expect.objectContaining({ name: 'ForgeTimeTrackerStart' }),
           expect.objectContaining({ name: 'ForgeTimeTrackerStatus' }),
+          expect.objectContaining({ name: 'ForgeTimeTrackerUpdate' }),
           expect.objectContaining({ name: 'ForgeTimeTrackerStop' }),
           expect.objectContaining({ name: 'ForgeTimeTrackerCancel' }),
+          expect.objectContaining({ name: 'ForgeTimeTrackerListSessions' }),
+          expect.objectContaining({ name: 'ForgeTimeTrackerRecordSession' }),
         ]),
       },
     });
@@ -164,6 +176,79 @@ describe('remote HTTP MCP handler', () => {
     });
   });
 
+  it('updates running sessions through the shared time tracker operation using write scope', async () => {
+    mocks.getRunningStateForUser.mockResolvedValue({
+      body: {
+        state: {
+          status: 'running',
+          draft: {
+            id: 'session-1',
+            title: 'Focus',
+            startedAt: '2026-05-01T00:00:00.000Z',
+          },
+          elapsedSeconds: 120,
+        },
+      },
+    });
+    mocks.updateRunningSessionForUser.mockResolvedValue({
+      body: {
+        state: {
+          status: 'running',
+          draft: {
+            id: 'session-1',
+            title: 'Corrected title',
+            startedAt: '2026-05-01T00:00:00.000Z',
+            project: 'AI駆動開発',
+          },
+          elapsedSeconds: 120,
+        },
+      },
+    });
+
+    const response = await handleMcp(
+      buildRequest({
+        jsonrpc: '2.0',
+        id: 22,
+        method: 'tools/call',
+        params: {
+          name: 'ForgeTimeTrackerUpdate',
+          arguments: {
+            id: 'session-1',
+            title: 'Corrected title',
+            project: 'AI駆動開発',
+            elapsedSeconds: 120,
+          },
+        },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.authorizeMcpToken).toHaveBeenCalledWith(
+      expect.any(Request),
+      env,
+      'time-tracker:write',
+    );
+    expect(mocks.updateRunningSessionForUser).toHaveBeenCalledWith(env, 'user-1', {
+      draft: {
+        id: 'session-1',
+        title: 'Corrected title',
+        startedAt: '2026-05-01T00:00:00.000Z',
+        project: 'AI駆動開発',
+      },
+      elapsedSeconds: 120,
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        structuredContent: {
+          state: {
+            draft: { title: 'Corrected title' },
+          },
+        },
+      },
+    });
+  });
+
   it('stops sessions and preserves Google sync details in structured content', async () => {
     mocks.stopRunningSessionForUser.mockResolvedValue({
       body: {
@@ -179,7 +264,13 @@ describe('remote HTTP MCP handler', () => {
         method: 'tools/call',
         params: {
           name: 'ForgeTimeTrackerStop',
-          arguments: { id: 'session-1' },
+          arguments: {
+            id: 'session-1',
+            title: 'Corrected title',
+            project: 'AI駆動開発',
+            tags: ['forge'],
+            notes: 'corrected at stop',
+          },
         },
       }),
       env,
@@ -188,11 +279,115 @@ describe('remote HTTP MCP handler', () => {
     expect(response.status).toBe(200);
     expect(mocks.stopRunningSessionForUser).toHaveBeenCalledWith(env, 'user-1', {
       id: 'session-1',
+      title: 'Corrected title',
+      project: 'AI駆動開発',
+      tags: ['forge'],
+      notes: 'corrected at stop',
     });
     await expect(response.json()).resolves.toMatchObject({
       result: {
         structuredContent: {
           sync: { status: 'skipped' },
+        },
+      },
+    });
+  });
+
+  it('lists sessions with read scope', async () => {
+    mocks.listSessionsForUser.mockResolvedValue({
+      body: {
+        sessions: [
+          {
+            id: 'session-1',
+            title: 'Focus',
+            startedAt: '2026-05-01T00:00:00.000Z',
+            endedAt: '2026-05-01T00:10:00.000Z',
+            durationSeconds: 600,
+          },
+        ],
+      },
+    });
+
+    const response = await handleMcp(
+      buildRequest({
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: {
+          name: 'ForgeTimeTrackerListSessions',
+          arguments: { limit: 5, query: 'Focus' },
+        },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.authorizeMcpToken).toHaveBeenCalledWith(
+      expect.any(Request),
+      env,
+      'time-tracker:read',
+    );
+    expect(mocks.listSessionsForUser).toHaveBeenCalledWith(env, 'user-1', {
+      limit: 5,
+      query: 'Focus',
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        structuredContent: {
+          sessions: [expect.objectContaining({ id: 'session-1' })],
+        },
+      },
+    });
+  });
+
+  it('records past sessions with write scope', async () => {
+    mocks.recordSessionForUser.mockResolvedValue({
+      body: {
+        session: {
+          id: 'session-1',
+          title: 'Manual record',
+          startedAt: '2026-05-01T00:00:00.000Z',
+          endedAt: '2026-05-01T00:30:00.000Z',
+          durationSeconds: 1800,
+        },
+        sync: { status: 'skipped', reason: 'connection_missing' },
+        warnings: [],
+      },
+    });
+
+    const response = await handleMcp(
+      buildRequest({
+        jsonrpc: '2.0',
+        id: 6,
+        method: 'tools/call',
+        params: {
+          name: 'ForgeTimeTrackerRecordSession',
+          arguments: {
+            title: 'Manual record',
+            startedAt: '2026-05-01T00:00:00.000Z',
+            endedAt: '2026-05-01T00:30:00.000Z',
+          },
+        },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.authorizeMcpToken).toHaveBeenCalledWith(
+      expect.any(Request),
+      env,
+      'time-tracker:write',
+    );
+    expect(mocks.recordSessionForUser).toHaveBeenCalledWith(env, 'user-1', {
+      title: 'Manual record',
+      startedAt: '2026-05-01T00:00:00.000Z',
+      endedAt: '2026-05-01T00:30:00.000Z',
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        structuredContent: {
+          session: { title: 'Manual record' },
+          warnings: [],
         },
       },
     });

--- a/api/src/handlers/__tests__/mcp.test.ts
+++ b/api/src/handlers/__tests__/mcp.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleMcp } from '../mcp';
+
+const mocks = vi.hoisted(() => {
+  const authorizeMcpToken = vi.fn();
+  const getRunningStateForUser = vi.fn();
+  const startRunningSessionForUser = vi.fn();
+  const stopRunningSessionForUser = vi.fn();
+  const cancelRunningSessionForUser = vi.fn();
+  return {
+    authorizeMcpToken,
+    getRunningStateForUser,
+    startRunningSessionForUser,
+    stopRunningSessionForUser,
+    cancelRunningSessionForUser,
+  };
+});
+
+vi.mock('../../auth/mcpTokenAuth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/mcpTokenAuth')>();
+  return {
+    ...actual,
+    authorizeMcpToken: mocks.authorizeMcpToken,
+  };
+});
+
+vi.mock('../timeTracker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../timeTracker')>();
+  return {
+    ...actual,
+    getRunningStateForUser: mocks.getRunningStateForUser,
+    startRunningSessionForUser: mocks.startRunningSessionForUser,
+    stopRunningSessionForUser: mocks.stopRunningSessionForUser,
+    cancelRunningSessionForUser: mocks.cancelRunningSessionForUser,
+  };
+});
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: '',
+  GOOGLE_CLIENT_SECRET: '',
+  GOOGLE_REDIRECT_URI: '',
+  MCP_TOKEN_HASH_PEPPER: 'pepper',
+} as const;
+
+const buildRequest = (body: unknown, headers: Record<string, string> = {}) =>
+  new Request('https://example.com/mcp', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer forge_mcp_${'a'.repeat(64)}`,
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+describe('remote HTTP MCP handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authorizeMcpToken.mockResolvedValue({
+      userId: 'user-1',
+      tokenId: 'token-1',
+      scopes: ['time-tracker:read', 'time-tracker:write'],
+    });
+  });
+
+  it('initializes a stateless MCP server with bearer auth', async () => {
+    const response = await handleMcp(
+      buildRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        capabilities: { tools: {} },
+        serverInfo: { name: 'forge-time-tracker' },
+      },
+    });
+    expect(mocks.authorizeMcpToken).toHaveBeenCalledWith(
+      expect.any(Request),
+      env,
+      'time-tracker:read',
+    );
+  });
+
+  it('lists the Forge time tracker tools', async () => {
+    const response = await handleMcp(
+      buildRequest({ jsonrpc: '2.0', id: 'tools', method: 'tools/list' }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: 'ForgeTimeTrackerStart' }),
+          expect.objectContaining({ name: 'ForgeTimeTrackerStatus' }),
+          expect.objectContaining({ name: 'ForgeTimeTrackerStop' }),
+          expect.objectContaining({ name: 'ForgeTimeTrackerCancel' }),
+        ]),
+      },
+    });
+  });
+
+  it('starts sessions through the shared time tracker operation using write scope', async () => {
+    mocks.startRunningSessionForUser.mockResolvedValue({
+      body: {
+        state: {
+          status: 'running',
+          draft: {
+            id: 'session-1',
+            title: 'Focus',
+            startedAt: '2026-05-01T00:00:00.000Z',
+          },
+          elapsedSeconds: 0,
+        },
+      },
+      status: 201,
+    });
+
+    const response = await handleMcp(
+      buildRequest({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'ForgeTimeTrackerStart',
+          arguments: {
+            id: 'session-1',
+            title: 'Focus',
+            startedAt: '2026-05-01T00:00:00.000Z',
+            project: 'Forge',
+          },
+        },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.authorizeMcpToken).toHaveBeenCalledWith(
+      expect.any(Request),
+      env,
+      'time-tracker:write',
+    );
+    expect(mocks.startRunningSessionForUser).toHaveBeenCalledWith(env, 'user-1', {
+      draft: expect.objectContaining({
+        id: 'session-1',
+        title: 'Focus',
+        project: 'Forge',
+      }),
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        structuredContent: {
+          state: {
+            status: 'running',
+          },
+        },
+      },
+    });
+  });
+
+  it('stops sessions and preserves Google sync details in structured content', async () => {
+    mocks.stopRunningSessionForUser.mockResolvedValue({
+      body: {
+        session: { id: 'session-1', title: 'Focus' },
+        sync: { status: 'skipped', reason: 'connection_missing' },
+      },
+    });
+
+    const response = await handleMcp(
+      buildRequest({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'ForgeTimeTrackerStop',
+          arguments: { id: 'session-1' },
+        },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.stopRunningSessionForUser).toHaveBeenCalledWith(env, 'user-1', {
+      id: 'session-1',
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      result: {
+        structuredContent: {
+          sync: { status: 'skipped' },
+        },
+      },
+    });
+  });
+
+  it('rejects mismatched MCP routing headers before tool execution', async () => {
+    const response = await handleMcp(
+      buildRequest({ jsonrpc: '2.0', id: 4, method: 'tools/list' }, { 'Mcp-Method': 'tools/call' }),
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.getRunningStateForUser).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/handlers/__tests__/mcpTokens.test.ts
+++ b/api/src/handlers/__tests__/mcpTokens.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleCreateMcpToken, handleListMcpTokens, handleRevokeMcpToken } from '../mcpTokens';
+
+const mocks = vi.hoisted(() => {
+  const verifySupabaseJwt = vi.fn();
+  const generateMcpToken = vi.fn();
+  const hashMcpToken = vi.fn();
+  const createMcpTokenRecord = vi.fn();
+  const listMcpTokenRecords = vi.fn();
+  const revokeMcpTokenRecord = vi.fn();
+  return {
+    verifySupabaseJwt,
+    generateMcpToken,
+    hashMcpToken,
+    createMcpTokenRecord,
+    listMcpTokenRecords,
+    revokeMcpTokenRecord,
+  };
+});
+
+vi.mock('../../auth/verifySupabaseJwt', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/verifySupabaseJwt')>();
+  return {
+    ...actual,
+    verifySupabaseJwt: mocks.verifySupabaseJwt,
+  };
+});
+
+vi.mock('../../security/mcpToken', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../security/mcpToken')>();
+  return {
+    ...actual,
+    generateMcpToken: mocks.generateMcpToken,
+    hashMcpToken: mocks.hashMcpToken,
+  };
+});
+
+vi.mock('../../repositories/mcpTokens', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../repositories/mcpTokens')>();
+  return {
+    ...actual,
+    createMcpTokenRecord: mocks.createMcpTokenRecord,
+    listMcpTokenRecords: mocks.listMcpTokenRecords,
+    revokeMcpTokenRecord: mocks.revokeMcpTokenRecord,
+  };
+});
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: '',
+  GOOGLE_CLIENT_SECRET: '',
+  GOOGLE_REDIRECT_URI: '',
+  MCP_TOKEN_HASH_PEPPER: 'pepper',
+} as const;
+
+const buildRequest = (method: string, body?: unknown, token = 'supabase-token') =>
+  new Request('https://example.com/mcp/tokens', {
+    method,
+    headers: token
+      ? {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        }
+      : {
+          'Content-Type': 'application/json',
+        },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+const tokenRow = {
+  id: 'token-1',
+  user_id: 'user-1',
+  name: 'Codex',
+  token_hash: 'hash',
+  scopes: ['time-tracker:read', 'time-tracker:write'],
+  expires_at: '2026-08-01T00:00:00.000Z',
+  revoked_at: null,
+  last_used_at: null,
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+} as const;
+
+describe('MCP token handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'));
+    mocks.verifySupabaseJwt.mockResolvedValue({ userId: 'user-1', raw: {} });
+    mocks.generateMcpToken.mockReturnValue(`forge_mcp_${'a'.repeat(64)}`);
+    mocks.hashMcpToken.mockResolvedValue('hash');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates a scoped token and returns the raw token exactly once', async () => {
+    mocks.createMcpTokenRecord.mockResolvedValue(tokenRow);
+
+    const response = await handleCreateMcpToken(
+      buildRequest('POST', {
+        name: 'Codex',
+        scopes: ['time-tracker:write', 'time-tracker:read'],
+        expiresInDays: 30,
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      token: `forge_mcp_${'a'.repeat(64)}`,
+      mcpToken: {
+        id: 'token-1',
+        name: 'Codex',
+        scopes: ['time-tracker:read', 'time-tracker:write'],
+        expiresAt: '2026-08-01T00:00:00.000Z',
+        revokedAt: null,
+        lastUsedAt: null,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+    });
+    expect(mocks.createMcpTokenRecord).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        userId: 'user-1',
+        tokenHash: 'hash',
+        scopes: ['time-tracker:write', 'time-tracker:read'],
+      }),
+    );
+  });
+
+  it('rejects malformed create requests before persisting a token', async () => {
+    const response = await handleCreateMcpToken(
+      buildRequest('POST', { name: 'Codex', scopes: ['admin'] }),
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.createMcpTokenRecord).not.toHaveBeenCalled();
+  });
+
+  it('lists token metadata without token hashes', async () => {
+    mocks.listMcpTokenRecords.mockResolvedValue([tokenRow]);
+
+    const response = await handleListMcpTokens(buildRequest('GET'), env);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      tokens: [
+        {
+          id: 'token-1',
+          name: 'Codex',
+          scopes: ['time-tracker:read', 'time-tracker:write'],
+          expiresAt: '2026-08-01T00:00:00.000Z',
+          revokedAt: null,
+          lastUsedAt: null,
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(JSON.stringify(body)).not.toContain('hash');
+  });
+
+  it('revokes only the authenticated user token', async () => {
+    mocks.revokeMcpTokenRecord.mockResolvedValue({
+      ...tokenRow,
+      revoked_at: '2026-05-01T01:00:00.000Z',
+    });
+
+    const response = await handleRevokeMcpToken(buildRequest('DELETE'), env, 'token-1');
+
+    expect(response.status).toBe(200);
+    expect(mocks.revokeMcpTokenRecord).toHaveBeenCalledWith(env, 'user-1', 'token-1');
+    await expect(response.json()).resolves.toMatchObject({
+      token: {
+        id: 'token-1',
+        revokedAt: '2026-05-01T01:00:00.000Z',
+      },
+    });
+  });
+
+  it('requires Supabase bearer auth to manage tokens', async () => {
+    const response = await handleListMcpTokens(buildRequest('GET', undefined, ''), env);
+
+    expect(response.status).toBe(401);
+    expect(mocks.listMcpTokenRecords).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/handlers/__tests__/timeTracker.test.ts
+++ b/api/src/handlers/__tests__/timeTracker.test.ts
@@ -12,13 +12,13 @@ const mocks = vi.hoisted(() => {
   const getRunningState = vi.fn();
   const upsertRunningState = vi.fn();
   const insertSession = vi.fn();
-  const handleSyncSession = vi.fn();
+  const syncSessionForUser = vi.fn();
   return {
     verifySupabaseJwt,
     getRunningState,
     upsertRunningState,
     insertSession,
-    handleSyncSession,
+    syncSessionForUser,
   };
 });
 
@@ -44,7 +44,7 @@ vi.mock('../syncSession', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../syncSession')>();
   return {
     ...actual,
-    handleSyncSession: mocks.handleSyncSession,
+    syncSessionForUser: mocks.syncSessionForUser,
   };
 });
 
@@ -94,7 +94,7 @@ describe('time tracker canonical Worker handlers', () => {
       userId: 'user-1',
       raw: {},
     });
-    mocks.handleSyncSession.mockResolvedValue(
+    mocks.syncSessionForUser.mockResolvedValue(
       new Response(
         JSON.stringify({
           error: 'connection_missing',
@@ -210,7 +210,7 @@ describe('time tracker canonical Worker handlers', () => {
     });
     expect(mocks.insertSession).toHaveBeenCalledWith(env, 'user-1', completedSession);
     expect(mocks.upsertRunningState).toHaveBeenCalledWith(env, 'user-1', idleState);
-    expect(mocks.handleSyncSession).toHaveBeenCalledTimes(1);
+    expect(mocks.syncSessionForUser).toHaveBeenCalledTimes(1);
   });
 
   it('returns Google Sheets sync success when stop sync succeeds', async () => {
@@ -235,7 +235,7 @@ describe('time tracker canonical Worker handlers', () => {
     mocks.getRunningState.mockResolvedValue(runningState);
     mocks.insertSession.mockResolvedValue(completedSession);
     mocks.upsertRunningState.mockResolvedValue(idleState);
-    mocks.handleSyncSession.mockResolvedValue(
+    mocks.syncSessionForUser.mockResolvedValue(
       new Response(JSON.stringify(syncLog), {
         status: 202,
         headers: { 'Content-Type': 'application/json' },
@@ -256,11 +256,13 @@ describe('time tracker canonical Worker handlers', () => {
         log: syncLog,
       },
     });
-    expect(mocks.handleSyncSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: 'POST',
-      }),
+    expect(mocks.syncSessionForUser).toHaveBeenCalledWith(
       env,
+      'user-1',
+      expect.objectContaining({
+        source: 'time-tracker-worker-api',
+        session: completedSession,
+      }),
     );
   });
 
@@ -279,7 +281,7 @@ describe('time tracker canonical Worker handlers', () => {
     mocks.getRunningState.mockResolvedValue(runningState);
     mocks.insertSession.mockResolvedValue(completedSession);
     mocks.upsertRunningState.mockResolvedValue(idleState);
-    mocks.handleSyncSession.mockResolvedValue(
+    mocks.syncSessionForUser.mockResolvedValue(
       new Response(
         JSON.stringify({
           error: 'internal_error',

--- a/api/src/handlers/__tests__/timeTracker.test.ts
+++ b/api/src/handlers/__tests__/timeTracker.test.ts
@@ -1,21 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   handleCancelRunningSession,
   handleGetRunningState,
   handleStartRunningSession,
   handleStopRunningSession,
   handleUpdateRunningSession,
+  listSessionsForUser,
+  recordSessionForUser,
 } from '../timeTracker';
 
 const mocks = vi.hoisted(() => {
   const verifySupabaseJwt = vi.fn();
   const getRunningState = vi.fn();
+  const listSessions = vi.fn();
   const upsertRunningState = vi.fn();
   const insertSession = vi.fn();
   const syncSessionForUser = vi.fn();
   return {
     verifySupabaseJwt,
     getRunningState,
+    listSessions,
     upsertRunningState,
     insertSession,
     syncSessionForUser,
@@ -35,6 +39,7 @@ vi.mock('../../repositories/timeTracker', async (importOriginal) => {
   return {
     ...actual,
     getRunningState: mocks.getRunningState,
+    listSessions: mocks.listSessions,
     upsertRunningState: mocks.upsertRunningState,
     insertSession: mocks.insertSession,
   };
@@ -90,6 +95,8 @@ const idleState = {
 describe('time tracker canonical Worker handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T12:00:00.000Z'));
     mocks.verifySupabaseJwt.mockResolvedValue({
       userId: 'user-1',
       raw: {},
@@ -108,6 +115,10 @@ describe('time tracker canonical Worker handlers', () => {
     );
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('returns idle state when the user has no running row', async () => {
     mocks.getRunningState.mockResolvedValue(null);
 
@@ -116,6 +127,31 @@ describe('time tracker canonical Worker handlers', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ state: idleState });
     expect(mocks.getRunningState).toHaveBeenCalledWith(env, 'user-1');
+  });
+
+  it('returns live elapsed seconds for running state status', async () => {
+    mocks.getRunningState.mockResolvedValue({
+      ...runningState,
+      draft: {
+        ...draft,
+        startedAt: '2026-05-01T11:55:00.000Z',
+      },
+      elapsedSeconds: 0,
+    });
+
+    const response = await handleGetRunningState(buildRequest('GET', '/time-tracker/running'), env);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      state: {
+        ...runningState,
+        draft: {
+          ...draft,
+          startedAt: '2026-05-01T11:55:00.000Z',
+        },
+        elapsedSeconds: 300,
+      },
+    });
   });
 
   it('starts a running session using the verified user id only', async () => {
@@ -213,6 +249,38 @@ describe('time tracker canonical Worker handlers', () => {
     expect(mocks.syncSessionForUser).toHaveBeenCalledTimes(1);
   });
 
+  it('applies stop-time metadata overrides to the completed session', async () => {
+    const stoppedAt = '2026-04-30T00:05:00.000Z';
+    const completedSession = {
+      id: 'session-1',
+      title: 'Corrected title',
+      startedAt: draft.startedAt,
+      endedAt: stoppedAt,
+      durationSeconds: 300,
+      project: 'AI駆動開発',
+      tags: ['forge', 'deploy'],
+      notes: 'corrected at stop',
+    };
+    mocks.getRunningState.mockResolvedValue(runningState);
+    mocks.insertSession.mockResolvedValue(completedSession);
+    mocks.upsertRunningState.mockResolvedValue(idleState);
+
+    const response = await handleStopRunningSession(
+      buildRequest('POST', '/time-tracker/running/stop', {
+        id: 'session-1',
+        stoppedAt,
+        title: 'Corrected title',
+        project: 'AI駆動開発',
+        tags: ['forge', 'deploy'],
+        notes: 'corrected at stop',
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.insertSession).toHaveBeenCalledWith(env, 'user-1', completedSession);
+  });
+
   it('returns Google Sheets sync success when stop sync succeeds', async () => {
     const stoppedAt = '2026-04-30T00:05:00.000Z';
     const completedSession = {
@@ -264,6 +332,117 @@ describe('time tracker canonical Worker handlers', () => {
         session: completedSession,
       }),
     );
+  });
+
+  it('lists completed sessions using bounded filters', async () => {
+    const sessions = [
+      {
+        id: 'session-1',
+        title: 'Focus',
+        startedAt: '2026-04-30T00:00:00.000Z',
+        endedAt: '2026-04-30T00:05:00.000Z',
+        durationSeconds: 300,
+      },
+    ];
+    mocks.listSessions.mockResolvedValue(sessions);
+
+    const result = await listSessionsForUser(env, 'user-1', {
+      limit: 5,
+      from: '2026-04-01T00:00:00.000Z',
+      query: 'Focus',
+      tags: ['mcp'],
+    });
+
+    expect(result).toEqual({ body: { sessions } });
+    expect(mocks.listSessions).toHaveBeenCalledWith(env, 'user-1', {
+      limit: 5,
+      from: '2026-04-01T00:00:00.000Z',
+      to: undefined,
+      query: 'Focus',
+      project: undefined,
+      tags: ['mcp'],
+    });
+  });
+
+  it('records a completed past session without touching running state', async () => {
+    const completedSession = {
+      id: 'session-1',
+      title: 'Manual record',
+      startedAt: '2026-05-01T00:00:00.000Z',
+      endedAt: '2026-05-01T00:30:00.000Z',
+      durationSeconds: 1800,
+      project: 'Forge',
+      tags: ['mcp'],
+    };
+    mocks.insertSession.mockResolvedValue(completedSession);
+
+    const result = await recordSessionForUser(env, 'user-1', {
+      id: 'session-1',
+      title: 'Manual record',
+      startedAt: completedSession.startedAt,
+      endedAt: completedSession.endedAt,
+      project: 'Forge',
+      tags: ['mcp'],
+    });
+
+    expect(result).toEqual({
+      status: 201,
+      body: {
+        session: completedSession,
+        warnings: [],
+        sync: {
+          status: 'skipped',
+          reason: 'Google spreadsheet connection not found',
+          detail: {
+            error: 'connection_missing',
+            message: 'Google spreadsheet connection not found',
+          },
+        },
+      },
+    });
+    expect(mocks.insertSession).toHaveBeenCalledWith(env, 'user-1', completedSession);
+    expect(mocks.getRunningState).not.toHaveBeenCalled();
+    expect(mocks.upsertRunningState).not.toHaveBeenCalled();
+  });
+
+  it('dry-runs manual records without persisting or syncing', async () => {
+    const result = await recordSessionForUser(env, 'user-1', {
+      id: 'session-1',
+      title: 'Manual record',
+      startedAt: '2026-05-01T00:00:00.000Z',
+      endedAt: '2026-05-01T00:30:00.000Z',
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      body: {
+        session: {
+          id: 'session-1',
+          title: 'Manual record',
+          startedAt: '2026-05-01T00:00:00.000Z',
+          endedAt: '2026-05-01T00:30:00.000Z',
+          durationSeconds: 1800,
+        },
+        dryRun: true,
+        warnings: [],
+        sync: { status: 'skipped', reason: 'dry_run' },
+      },
+    });
+    expect(mocks.insertSession).not.toHaveBeenCalled();
+    expect(mocks.syncSessionForUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects manual records in the future', async () => {
+    await expect(
+      recordSessionForUser(env, 'user-1', {
+        title: 'Future record',
+        startedAt: '2026-05-02T00:00:00.000Z',
+        endedAt: '2026-05-02T00:30:00.000Z',
+      }),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({ status: 400 }),
+    });
+    expect(mocks.insertSession).not.toHaveBeenCalled();
   });
 
   it('keeps the completed session when Google Sheets sync fails', async () => {

--- a/api/src/handlers/budgetsMetrics.ts
+++ b/api/src/handlers/budgetsMetrics.ts
@@ -1,0 +1,215 @@
+import type { Env } from '../env';
+import { deleteBudget, listBudgets, upsertBudget } from '../repositories/budgets';
+import {
+  deleteDefinition,
+  deleteEntry,
+  findDefinitionByName,
+  listDefinitions,
+  listEntries,
+  upsertDefinition,
+  upsertEntry,
+} from '../repositories/dailyMetrics';
+import type {
+  BudgetPayload,
+  MetricDefinitionPayload,
+  MetricKind,
+  MetricValuePayload,
+} from '../types';
+
+const asObject = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value.trim();
+};
+
+const optionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const DATE_KEY = /^\d{4}-\d{2}-\d{2}$/;
+const requireDateKey = (value: unknown, field: string): string => {
+  const str = requireString(value, field);
+  if (!DATE_KEY.test(str)) {
+    throw new Error(`${field} must be formatted as YYYY-MM-DD`);
+  }
+  return str;
+};
+
+const utcTodayKey = (): string => new Date().toISOString().slice(0, 10);
+
+const toNumberArray7 = (value: unknown, field: string): number[] => {
+  if (!Array.isArray(value) || value.length !== 7) {
+    throw new Error(`${field} must be an array of 7 numbers (Sun..Sat)`);
+  }
+  return value.map((item) => {
+    const num = typeof item === 'number' ? item : Number(item);
+    return Number.isFinite(num) && num >= 0 ? num : 0;
+  });
+};
+
+// ===== 予実 =====
+export const listBudgetsForUser = async (env: Env, userId: string) => ({
+  budgets: await listBudgets(env, userId),
+});
+
+export const setBudgetForUser = async (env: Env, userId: string, argumentsValue: unknown) => {
+  const args = asObject(argumentsValue);
+  let weekdayMinutes: number[];
+  if (args.weekdayMinutes !== undefined) {
+    weekdayMinutes = toNumberArray7(args.weekdayMinutes, 'weekdayMinutes');
+  } else if (args.weekdayHours !== undefined) {
+    weekdayMinutes = toNumberArray7(args.weekdayHours, 'weekdayHours').map((hours) =>
+      Math.round(hours * 60),
+    );
+  } else {
+    throw new Error('weekdayMinutes or weekdayHours is required');
+  }
+
+  const budget: BudgetPayload = {
+    id: optionalString(args.id) ?? crypto.randomUUID(),
+    tag: requireString(args.tag, 'tag'),
+    label: optionalString(args.label) ?? null,
+    weekdayMinutes,
+    effectiveFrom: requireDateKey(args.effectiveFrom, 'effectiveFrom'),
+    effectiveTo:
+      typeof args.effectiveTo === 'string' && DATE_KEY.test(args.effectiveTo)
+        ? args.effectiveTo
+        : null,
+  };
+  return { budget: await upsertBudget(env, userId, budget) };
+};
+
+export const deleteBudgetForUser = async (env: Env, userId: string, argumentsValue: unknown) => {
+  const args = asObject(argumentsValue);
+  const id = requireString(args.id, 'id');
+  await deleteBudget(env, userId, id);
+  return { deleted: id };
+};
+
+// ===== デイリー記録 =====
+const KINDS = new Set<MetricKind>(['boolean', 'number', 'text', 'single_select', 'multi_select']);
+
+const validateValueForKind = (kind: MetricKind, value: unknown): MetricValuePayload => {
+  switch (kind) {
+    case 'boolean':
+      if (typeof value !== 'boolean') throw new Error('value must be a boolean');
+      return value;
+    case 'number':
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error('value must be a finite number');
+      }
+      return value;
+    case 'text':
+    case 'single_select':
+      if (typeof value !== 'string') throw new Error('value must be a string');
+      return value;
+    case 'multi_select':
+      if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+        throw new Error('value must be an array of strings');
+      }
+      return value as string[];
+    default:
+      throw new Error(`Unsupported metric kind: ${kind}`);
+  }
+};
+
+export const listMetricDefinitionsForUser = async (env: Env, userId: string) => ({
+  definitions: await listDefinitions(env, userId),
+});
+
+export const defineMetricForUser = async (env: Env, userId: string, argumentsValue: unknown) => {
+  const args = asObject(argumentsValue);
+  const kind = requireString(args.kind, 'kind') as MetricKind;
+  if (!KINDS.has(kind)) {
+    throw new Error(`kind must be one of: ${[...KINDS].join(', ')}`);
+  }
+  const options = Array.isArray(args.options)
+    ? args.options
+        .map((option) => {
+          const record = asObject(option);
+          const value = optionalString(record.value) ?? optionalString(record.label);
+          if (!value) return null;
+          return { value, label: optionalString(record.label) ?? value };
+        })
+        .filter((option): option is { value: string; label: string } => option !== null)
+    : null;
+
+  const definition: MetricDefinitionPayload = {
+    id: optionalString(args.id) ?? crypto.randomUUID(),
+    name: requireString(args.name, 'name'),
+    kind,
+    unit: optionalString(args.unit) ?? null,
+    options: kind === 'single_select' || kind === 'multi_select' ? options : null,
+    targetNumber: typeof args.targetNumber === 'number' ? args.targetNumber : null,
+    displayOrder: typeof args.displayOrder === 'number' ? args.displayOrder : 0,
+    archivedAt: null,
+  };
+  return { definition: await upsertDefinition(env, userId, definition) };
+};
+
+export const recordMetricForUser = async (env: Env, userId: string, argumentsValue: unknown) => {
+  const args = asObject(argumentsValue);
+  const metricId = optionalString(args.metricId);
+  const metricName = optionalString(args.metricName);
+
+  let definition: MetricDefinitionPayload | null = null;
+  if (metricId) {
+    definition = (await listDefinitions(env, userId)).find((item) => item.id === metricId) ?? null;
+  } else if (metricName) {
+    definition = await findDefinitionByName(env, userId, metricName);
+  } else {
+    throw new Error('metricId or metricName is required');
+  }
+  if (!definition) {
+    throw new Error('metric definition not found');
+  }
+
+  const entryDate =
+    args.entryDate === undefined ? utcTodayKey() : requireDateKey(args.entryDate, 'entryDate');
+  const value = validateValueForKind(definition.kind, args.value);
+
+  const entry = await upsertEntry(env, userId, {
+    metricId: definition.id,
+    entryDate,
+    value,
+  });
+  return { entry, metric: { id: definition.id, name: definition.name, kind: definition.kind } };
+};
+
+export const listMetricEntriesForUser = async (
+  env: Env,
+  userId: string,
+  argumentsValue: unknown,
+) => {
+  const args = asObject(argumentsValue);
+  const from = requireDateKey(args.from, 'from');
+  const to = requireDateKey(args.to, 'to');
+  return { entries: await listEntries(env, userId, from, to) };
+};
+
+export const deleteMetricForUser = async (env: Env, userId: string, argumentsValue: unknown) => {
+  const args = asObject(argumentsValue);
+  const id = requireString(args.id, 'id');
+  await deleteDefinition(env, userId, id);
+  return { deleted: id };
+};
+
+export const deleteMetricEntryForUser = async (
+  env: Env,
+  userId: string,
+  argumentsValue: unknown,
+) => {
+  const args = asObject(argumentsValue);
+  const metricId = requireString(args.metricId, 'metricId');
+  const entryDate = requireDateKey(args.entryDate, 'entryDate');
+  await deleteEntry(env, userId, metricId, entryDate);
+  return { deleted: { metricId, entryDate } };
+};

--- a/api/src/handlers/mcp.ts
+++ b/api/src/handlers/mcp.ts
@@ -1,0 +1,338 @@
+import { authorizeMcpToken, McpTokenAuthError } from '../auth/mcpTokenAuth';
+import type { Env } from '../env';
+import { badRequest, jsonResponse, serverError, unauthorized } from '../http/response';
+import type { McpTokenScope } from '../repositories/mcpTokens';
+import type {
+  RunningSessionCancelRequest,
+  RunningSessionDraftPayload,
+  RunningSessionStopRequest,
+} from '../types';
+import {
+  cancelRunningSessionForUser,
+  getRunningStateForUser,
+  startRunningSessionForUser,
+  stopRunningSessionForUser,
+} from './timeTracker';
+
+const PROTOCOL_VERSION = '2025-11-25';
+
+const TOOL_NAMES = {
+  START: 'ForgeTimeTrackerStart',
+  STATUS: 'ForgeTimeTrackerStatus',
+  STOP: 'ForgeTimeTrackerStop',
+  CANCEL: 'ForgeTimeTrackerCancel',
+} as const;
+
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+  jsonrpc?: '2.0';
+  id?: JsonRpcId;
+  method?: string;
+  params?: unknown;
+};
+
+type ToolCallParams = {
+  name?: string;
+  arguments?: unknown;
+};
+
+const asObject = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+};
+
+const parseJsonRpcRequest = async (request: Request): Promise<JsonRpcRequest> => {
+  const parsed = await request.json();
+  const value = asObject(parsed);
+  if (!value) {
+    throw new Error('JSON-RPC request object is required');
+  }
+  if (value.jsonrpc !== '2.0') {
+    throw new Error('jsonrpc must be "2.0"');
+  }
+  if (typeof value.method !== 'string' || value.method.trim().length === 0) {
+    throw new Error('method is required');
+  }
+  return value as JsonRpcRequest;
+};
+
+const jsonRpcResponse = (id: JsonRpcId | undefined, result: unknown): Response =>
+  jsonResponse({
+    jsonrpc: '2.0',
+    id: id ?? null,
+    result,
+  });
+
+const jsonRpcError = (
+  id: JsonRpcId | undefined,
+  code: number,
+  message: string,
+  status = 200,
+): Response =>
+  jsonResponse(
+    {
+      jsonrpc: '2.0',
+      id: id ?? null,
+      error: {
+        code,
+        message,
+      },
+    },
+    status,
+  );
+
+const unauthorizedMcp = (message: string, status: number): Response => {
+  const response =
+    status === 401 ? unauthorized(message) : jsonResponse({ error: 'forbidden', message }, 403);
+  response.headers.set('WWW-Authenticate', 'Bearer');
+  return response;
+};
+
+const validateMcpMethodHeader = (request: Request, rpc: JsonRpcRequest): Response | null => {
+  const methodHeader = request.headers.get('Mcp-Method');
+  if (methodHeader && methodHeader !== rpc.method) {
+    return badRequest('Mcp-Method header does not match JSON-RPC method');
+  }
+  if (rpc.method === 'tools/call') {
+    const nameHeader = request.headers.get('Mcp-Name');
+    const params = asObject(rpc.params) as ToolCallParams | null;
+    if (nameHeader && nameHeader !== params?.name) {
+      return badRequest('Mcp-Name header does not match JSON-RPC tool name');
+    }
+  }
+  return null;
+};
+
+const toolRequiresScope = (rpc: JsonRpcRequest): McpTokenScope => {
+  if (rpc.method !== 'tools/call') {
+    return 'time-tracker:read';
+  }
+
+  const params = asObject(rpc.params) as ToolCallParams | null;
+  switch (params?.name) {
+    case TOOL_NAMES.START:
+    case TOOL_NAMES.STOP:
+    case TOOL_NAMES.CANCEL:
+      return 'time-tracker:write';
+    default:
+      return 'time-tracker:read';
+  }
+};
+
+const listToolsResult = () => ({
+  tools: [
+    {
+      name: TOOL_NAMES.START,
+      description: 'Start a Forge time-tracker session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          project: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          notes: { type: 'string' },
+          skill: { type: 'string' },
+          intensity: { type: 'string' },
+          startedAt: { type: 'string' },
+          id: { type: 'string' },
+          draft: { type: 'object' },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.STATUS,
+      description: 'Get the current Forge time-tracker running state.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.STOP,
+      description: 'Stop the current Forge time-tracker session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          stoppedAt: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.CANCEL,
+      description: 'Cancel the current Forge time-tracker session without recording it.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
+    },
+  ],
+});
+
+const toolResult = (value: unknown) => ({
+  content: [
+    {
+      type: 'text',
+      text: JSON.stringify(value, null, 2),
+    },
+  ],
+  structuredContent: value,
+});
+
+const optionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const buildDraftFromArguments = (argumentsValue: unknown): RunningSessionDraftPayload => {
+  const args = asObject(argumentsValue) ?? {};
+  const draftArg = asObject(args.draft);
+  if (draftArg) {
+    return draftArg as RunningSessionDraftPayload;
+  }
+
+  const title = optionalString(args.title);
+  if (!title) {
+    throw new Error('title is required');
+  }
+
+  const draft: RunningSessionDraftPayload = {
+    id: optionalString(args.id) ?? crypto.randomUUID(),
+    title,
+    startedAt: optionalString(args.startedAt) ?? new Date().toISOString(),
+  };
+  const project = optionalString(args.project);
+  if (project) draft.project = project;
+  const notes = optionalString(args.notes);
+  if (notes) draft.notes = notes;
+  const skill = optionalString(args.skill);
+  if (skill) draft.skill = skill;
+  const intensity = optionalString(args.intensity);
+  if (intensity) draft.intensity = intensity;
+  if (Array.isArray(args.tags)) {
+    draft.tags = args.tags.filter((tag): tag is string => typeof tag === 'string');
+  }
+  return draft;
+};
+
+const executeTool = async (
+  env: Env,
+  userId: string,
+  name: string,
+  argumentsValue: unknown,
+): Promise<unknown> => {
+  switch (name) {
+    case TOOL_NAMES.START: {
+      const result = await startRunningSessionForUser(env, userId, {
+        draft: buildDraftFromArguments(argumentsValue),
+      });
+      return result.body;
+    }
+    case TOOL_NAMES.STATUS: {
+      const result = await getRunningStateForUser(env, userId);
+      return result.body;
+    }
+    case TOOL_NAMES.STOP: {
+      const args = asObject(argumentsValue) ?? {};
+      const payload: RunningSessionStopRequest = {};
+      const id = optionalString(args.id);
+      if (id) payload.id = id;
+      const stoppedAt = optionalString(args.stoppedAt);
+      if (stoppedAt) payload.stoppedAt = stoppedAt;
+      const result = await stopRunningSessionForUser(env, userId, payload);
+      return result.body;
+    }
+    case TOOL_NAMES.CANCEL: {
+      const args = asObject(argumentsValue) ?? {};
+      const payload: RunningSessionCancelRequest = {};
+      const id = optionalString(args.id);
+      if (id) payload.id = id;
+      const result = await cancelRunningSessionForUser(env, userId, payload);
+      return result.body;
+    }
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+};
+
+const handleJsonRpc = async (
+  request: Request,
+  env: Env,
+  rpc: JsonRpcRequest,
+): Promise<Response> => {
+  const headerError = validateMcpMethodHeader(request, rpc);
+  if (headerError) return headerError;
+
+  const requiredScope = toolRequiresScope(rpc);
+  let auth;
+  try {
+    auth = await authorizeMcpToken(request, env, requiredScope);
+  } catch (error) {
+    if (error instanceof McpTokenAuthError) {
+      return unauthorizedMcp(error.message, error.status);
+    }
+    if (error instanceof Error) {
+      return serverError(error.message);
+    }
+    return serverError('Unknown error');
+  }
+
+  if (rpc.id === undefined) {
+    return new Response(null, { status: 202 });
+  }
+
+  switch (rpc.method) {
+    case 'initialize':
+      return jsonRpcResponse(rpc.id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: {
+          name: 'forge-time-tracker',
+          version: '0.1.0',
+        },
+      });
+    case 'tools/list':
+      return jsonRpcResponse(rpc.id, listToolsResult());
+    case 'tools/call': {
+      const params = asObject(rpc.params) as ToolCallParams | null;
+      if (!params || typeof params.name !== 'string') {
+        return jsonRpcError(rpc.id, -32602, 'tools/call params.name is required');
+      }
+      try {
+        const result = await executeTool(env, auth.userId, params.name, params.arguments);
+        return jsonRpcResponse(rpc.id, toolResult(result));
+      } catch (error) {
+        return jsonRpcError(
+          rpc.id,
+          -32000,
+          error instanceof Error ? error.message : 'Tool execution failed',
+        );
+      }
+    }
+    default:
+      return jsonRpcError(rpc.id, -32601, `Method not found: ${rpc.method}`);
+  }
+};
+
+export const handleMcp = async (request: Request, env: Env): Promise<Response> => {
+  let rpc: JsonRpcRequest;
+  try {
+    rpc = await parseJsonRpcRequest(request);
+  } catch (error) {
+    return jsonRpcError(null, -32700, error instanceof Error ? error.message : 'Parse error', 400);
+  }
+
+  return handleJsonRpc(request, env, rpc);
+};

--- a/api/src/handlers/mcp.ts
+++ b/api/src/handlers/mcp.ts
@@ -5,13 +5,30 @@ import type { McpTokenScope } from '../repositories/mcpTokens';
 import type {
   RunningSessionCancelRequest,
   RunningSessionDraftPayload,
+  RunningSessionStatePayload,
   RunningSessionStopRequest,
+  TimeTrackerSessionListRequest,
+  TimeTrackerSessionRecordRequest,
 } from '../types';
+import {
+  defineMetricForUser,
+  deleteBudgetForUser,
+  deleteMetricEntryForUser,
+  deleteMetricForUser,
+  listBudgetsForUser,
+  listMetricDefinitionsForUser,
+  listMetricEntriesForUser,
+  recordMetricForUser,
+  setBudgetForUser,
+} from './budgetsMetrics';
 import {
   cancelRunningSessionForUser,
   getRunningStateForUser,
+  listSessionsForUser,
+  recordSessionForUser,
   startRunningSessionForUser,
   stopRunningSessionForUser,
+  updateRunningSessionForUser,
 } from './timeTracker';
 
 const PROTOCOL_VERSION = '2025-11-25';
@@ -19,8 +36,20 @@ const PROTOCOL_VERSION = '2025-11-25';
 const TOOL_NAMES = {
   START: 'ForgeTimeTrackerStart',
   STATUS: 'ForgeTimeTrackerStatus',
+  UPDATE: 'ForgeTimeTrackerUpdate',
   STOP: 'ForgeTimeTrackerStop',
   CANCEL: 'ForgeTimeTrackerCancel',
+  LIST_SESSIONS: 'ForgeTimeTrackerListSessions',
+  RECORD_SESSION: 'ForgeTimeTrackerRecordSession',
+  BUDGET_LIST: 'ForgeBudgetList',
+  BUDGET_SET: 'ForgeBudgetSet',
+  BUDGET_DELETE: 'ForgeBudgetDelete',
+  METRIC_DEF_LIST: 'ForgeDailyMetricListDefinitions',
+  METRIC_DEFINE: 'ForgeDailyMetricDefine',
+  METRIC_DELETE: 'ForgeDailyMetricDeleteDefinition',
+  METRIC_RECORD: 'ForgeDailyMetricRecord',
+  METRIC_ENTRIES: 'ForgeDailyMetricListEntries',
+  METRIC_ENTRY_DELETE: 'ForgeDailyMetricDeleteEntry',
 } as const;
 
 type JsonRpcId = string | number | null;
@@ -114,8 +143,16 @@ const toolRequiresScope = (rpc: JsonRpcRequest): McpTokenScope => {
   const params = asObject(rpc.params) as ToolCallParams | null;
   switch (params?.name) {
     case TOOL_NAMES.START:
+    case TOOL_NAMES.UPDATE:
     case TOOL_NAMES.STOP:
     case TOOL_NAMES.CANCEL:
+    case TOOL_NAMES.RECORD_SESSION:
+    case TOOL_NAMES.BUDGET_SET:
+    case TOOL_NAMES.BUDGET_DELETE:
+    case TOOL_NAMES.METRIC_DEFINE:
+    case TOOL_NAMES.METRIC_DELETE:
+    case TOOL_NAMES.METRIC_RECORD:
+    case TOOL_NAMES.METRIC_ENTRY_DELETE:
       return 'time-tracker:write';
     default:
       return 'time-tracker:read';
@@ -153,6 +190,25 @@ const listToolsResult = () => ({
       },
     },
     {
+      name: TOOL_NAMES.UPDATE,
+      description: 'Update the current Forge time-tracker running session metadata.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          startedAt: { type: 'string' },
+          project: { type: 'string' },
+          notes: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          skill: { type: 'string' },
+          intensity: { type: 'string' },
+          elapsedSeconds: { type: 'number' },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
       name: TOOL_NAMES.STOP,
       description: 'Stop the current Forge time-tracker session.',
       inputSchema: {
@@ -160,6 +216,12 @@ const listToolsResult = () => ({
         properties: {
           id: { type: 'string' },
           stoppedAt: { type: 'string' },
+          title: { type: 'string' },
+          project: { type: 'string' },
+          notes: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          skill: { type: 'string' },
+          intensity: { type: 'string' },
         },
         additionalProperties: false,
       },
@@ -172,6 +234,162 @@ const listToolsResult = () => ({
         properties: {
           id: { type: 'string' },
         },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.LIST_SESSIONS,
+      description: 'List recent completed Forge time-tracker sessions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', minimum: 1, maximum: 50 },
+          from: { type: 'string' },
+          to: { type: 'string' },
+          query: { type: 'string' },
+          project: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.RECORD_SESSION,
+      description: 'Record a completed Forge time-tracker session for a past time range.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          startedAt: { type: 'string' },
+          endedAt: { type: 'string' },
+          project: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          notes: { type: 'string' },
+          skill: { type: 'string' },
+          intensity: { type: 'string' },
+          dryRun: { type: 'boolean' },
+        },
+        required: ['title', 'startedAt', 'endedAt'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.BUDGET_LIST,
+      description: 'List the tag-based work-time budgets (with weekday schedules).',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    },
+    {
+      name: TOOL_NAMES.BUDGET_SET,
+      description:
+        'Create or update a tag-based work-time budget. Provide weekdayHours (preferred) or weekdayMinutes as a length-7 array indexed Sunday..Saturday. Pass id to update an existing budget.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          tag: { type: 'string' },
+          label: { type: 'string' },
+          weekdayHours: { type: 'array', items: { type: 'number' }, minItems: 7, maxItems: 7 },
+          weekdayMinutes: { type: 'array', items: { type: 'number' }, minItems: 7, maxItems: 7 },
+          effectiveFrom: { type: 'string', description: 'YYYY-MM-DD' },
+          effectiveTo: { type: 'string', description: 'YYYY-MM-DD' },
+        },
+        required: ['tag', 'effectiveFrom'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.BUDGET_DELETE,
+      description: 'Delete a work-time budget by id.',
+      inputSchema: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.METRIC_DEF_LIST,
+      description: 'List the daily custom record definitions (checkbox/number/text/select).',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    },
+    {
+      name: TOOL_NAMES.METRIC_DEFINE,
+      description:
+        'Create or update a daily record definition. kind is one of boolean, number, text, single_select, multi_select. For select kinds pass options as [{value,label}]. Pass id to update.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          kind: {
+            type: 'string',
+            enum: ['boolean', 'number', 'text', 'single_select', 'multi_select'],
+          },
+          unit: { type: 'string' },
+          options: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { value: { type: 'string' }, label: { type: 'string' } },
+            },
+          },
+          targetNumber: { type: 'number' },
+          displayOrder: { type: 'number' },
+        },
+        required: ['name', 'kind'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.METRIC_DELETE,
+      description: 'Delete a daily record definition (and its entries) by id.',
+      inputSchema: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.METRIC_RECORD,
+      description:
+        'Record (upsert) a daily value. Identify the metric by metricId or metricName. value type must match the metric kind (boolean/number/string/string[]). entryDate defaults to today (UTC) if omitted.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          metricId: { type: 'string' },
+          metricName: { type: 'string' },
+          entryDate: { type: 'string', description: 'YYYY-MM-DD (defaults to today)' },
+          value: {},
+        },
+        required: ['value'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.METRIC_ENTRIES,
+      description: 'List daily record entries within a date range.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          from: { type: 'string', description: 'YYYY-MM-DD' },
+          to: { type: 'string', description: 'YYYY-MM-DD' },
+        },
+        required: ['from', 'to'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: TOOL_NAMES.METRIC_ENTRY_DELETE,
+      description: 'Delete a daily record entry by metricId and entryDate.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          metricId: { type: 'string' },
+          entryDate: { type: 'string', description: 'YYYY-MM-DD' },
+        },
+        required: ['metricId', 'entryDate'],
         additionalProperties: false,
       },
     },
@@ -192,6 +410,11 @@ const optionalString = (value: unknown): string | undefined => {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const optionalNumber = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  return Math.floor(value);
 };
 
 const buildDraftFromArguments = (argumentsValue: unknown): RunningSessionDraftPayload => {
@@ -225,6 +448,47 @@ const buildDraftFromArguments = (argumentsValue: unknown): RunningSessionDraftPa
   return draft;
 };
 
+const buildRunningUpdateFromArguments = async (
+  env: Env,
+  userId: string,
+  argumentsValue: unknown,
+): Promise<{ draft: RunningSessionDraftPayload; elapsedSeconds: number }> => {
+  const statusResult = await getRunningStateForUser(env, userId);
+  const currentState = (statusResult.body as { state?: RunningSessionStatePayload }).state;
+  if (!currentState || currentState.status !== 'running') {
+    throw new Error('No running session exists');
+  }
+
+  const args = asObject(argumentsValue) ?? {};
+  const id = optionalString(args.id);
+  if (id && currentState.draft.id !== id) {
+    throw new Error('Running session id does not match');
+  }
+
+  const draft: RunningSessionDraftPayload = { ...currentState.draft };
+  const title = optionalString(args.title);
+  if (title) draft.title = title;
+  const startedAt = optionalString(args.startedAt);
+  if (startedAt) draft.startedAt = startedAt;
+  const project = optionalString(args.project);
+  if (project) draft.project = project;
+  const notes = optionalString(args.notes);
+  if (notes) draft.notes = notes;
+  const skill = optionalString(args.skill);
+  if (skill) draft.skill = skill;
+  const intensity = optionalString(args.intensity);
+  if (intensity) draft.intensity = intensity;
+  if (Array.isArray(args.tags)) {
+    draft.tags = args.tags.filter((tag): tag is string => typeof tag === 'string');
+  }
+
+  const elapsedSeconds =
+    optionalNumber(args.elapsedSeconds) ??
+    Math.max(0, Math.floor((Date.now() - new Date(draft.startedAt).getTime()) / 1000));
+
+  return { draft, elapsedSeconds };
+};
+
 const executeTool = async (
   env: Env,
   userId: string,
@@ -242,6 +506,19 @@ const executeTool = async (
       const result = await getRunningStateForUser(env, userId);
       return result.body;
     }
+    case TOOL_NAMES.UPDATE: {
+      const result = await updateRunningSessionForUser(
+        env,
+        userId,
+        await buildRunningUpdateFromArguments(env, userId, argumentsValue),
+      );
+      return result.body;
+    }
+    case TOOL_NAMES.LIST_SESSIONS: {
+      const args = (asObject(argumentsValue) ?? {}) as TimeTrackerSessionListRequest;
+      const result = await listSessionsForUser(env, userId, args);
+      return result.body;
+    }
     case TOOL_NAMES.STOP: {
       const args = asObject(argumentsValue) ?? {};
       const payload: RunningSessionStopRequest = {};
@@ -249,6 +526,19 @@ const executeTool = async (
       if (id) payload.id = id;
       const stoppedAt = optionalString(args.stoppedAt);
       if (stoppedAt) payload.stoppedAt = stoppedAt;
+      const title = optionalString(args.title);
+      if (title) payload.title = title;
+      const project = optionalString(args.project);
+      if (project) payload.project = project;
+      const notes = optionalString(args.notes);
+      if (notes) payload.notes = notes;
+      const skill = optionalString(args.skill);
+      if (skill) payload.skill = skill;
+      const intensity = optionalString(args.intensity);
+      if (intensity) payload.intensity = intensity;
+      if (Array.isArray(args.tags)) {
+        payload.tags = args.tags.filter((tag): tag is string => typeof tag === 'string');
+      }
       const result = await stopRunningSessionForUser(env, userId, payload);
       return result.body;
     }
@@ -260,6 +550,29 @@ const executeTool = async (
       const result = await cancelRunningSessionForUser(env, userId, payload);
       return result.body;
     }
+    case TOOL_NAMES.RECORD_SESSION: {
+      const args = (asObject(argumentsValue) ?? {}) as TimeTrackerSessionRecordRequest;
+      const result = await recordSessionForUser(env, userId, args);
+      return result.body;
+    }
+    case TOOL_NAMES.BUDGET_LIST:
+      return listBudgetsForUser(env, userId);
+    case TOOL_NAMES.BUDGET_SET:
+      return setBudgetForUser(env, userId, argumentsValue);
+    case TOOL_NAMES.BUDGET_DELETE:
+      return deleteBudgetForUser(env, userId, argumentsValue);
+    case TOOL_NAMES.METRIC_DEF_LIST:
+      return listMetricDefinitionsForUser(env, userId);
+    case TOOL_NAMES.METRIC_DEFINE:
+      return defineMetricForUser(env, userId, argumentsValue);
+    case TOOL_NAMES.METRIC_DELETE:
+      return deleteMetricForUser(env, userId, argumentsValue);
+    case TOOL_NAMES.METRIC_RECORD:
+      return recordMetricForUser(env, userId, argumentsValue);
+    case TOOL_NAMES.METRIC_ENTRIES:
+      return listMetricEntriesForUser(env, userId, argumentsValue);
+    case TOOL_NAMES.METRIC_ENTRY_DELETE:
+      return deleteMetricEntryForUser(env, userId, argumentsValue);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/api/src/handlers/mcpTokens.ts
+++ b/api/src/handlers/mcpTokens.ts
@@ -1,0 +1,166 @@
+import {
+  extractBearerToken,
+  SupabaseAuthError,
+  verifySupabaseJwt,
+} from '../auth/verifySupabaseJwt';
+import type { Env } from '../env';
+import { badRequest, jsonResponse, serverError, unauthorized } from '../http/response';
+import {
+  createMcpTokenRecord,
+  listMcpTokenRecords,
+  MCP_TOKEN_SCOPES,
+  type McpTokenScope,
+  revokeMcpTokenRecord,
+  toPublicMcpToken,
+} from '../repositories/mcpTokens';
+import { generateMcpToken, hashMcpToken, McpTokenCryptoError } from '../security/mcpToken';
+
+const DEFAULT_EXPIRES_IN_DAYS = 90;
+const MAX_EXPIRES_IN_DAYS = 365;
+
+class RequestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestValidationError';
+  }
+}
+
+const ensureSupabaseUser = async (request: Request, env: Env): Promise<{ userId: string }> => {
+  const token = extractBearerToken(request);
+  if (!token) {
+    throw new SupabaseAuthError('Bearer token is required', 401);
+  }
+  return verifySupabaseJwt(token, env);
+};
+
+const asObject = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+};
+
+const parseBody = async (request: Request): Promise<Record<string, unknown>> => {
+  try {
+    return asObject(await request.json()) ?? {};
+  } catch {
+    return {};
+  }
+};
+
+const normalizeName = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    throw new RequestValidationError('name is required');
+  }
+  const name = value.trim();
+  if (name.length === 0) {
+    throw new RequestValidationError('name is required');
+  }
+  if (name.length > 80) {
+    throw new RequestValidationError('name must be at most 80 characters');
+  }
+  return name;
+};
+
+const normalizeScopes = (value: unknown): McpTokenScope[] => {
+  if (value === undefined) {
+    return [...MCP_TOKEN_SCOPES];
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new RequestValidationError('scopes must be a non-empty array');
+  }
+
+  const normalized = new Set<McpTokenScope>();
+  for (const scope of value) {
+    if (!MCP_TOKEN_SCOPES.includes(scope as McpTokenScope)) {
+      throw new RequestValidationError(`unsupported scope: ${String(scope)}`);
+    }
+    normalized.add(scope as McpTokenScope);
+  }
+  return [...normalized];
+};
+
+const normalizeExpiresAt = (value: unknown): string => {
+  const days = value === undefined ? DEFAULT_EXPIRES_IN_DAYS : value;
+  if (typeof days !== 'number' || !Number.isFinite(days)) {
+    throw new RequestValidationError('expiresInDays must be a number');
+  }
+  if (days < 1 || days > MAX_EXPIRES_IN_DAYS) {
+    throw new RequestValidationError(`expiresInDays must be between 1 and ${MAX_EXPIRES_IN_DAYS}`);
+  }
+
+  const expiresAt = new Date(Date.now() + Math.floor(days) * 24 * 60 * 60 * 1000);
+  return expiresAt.toISOString();
+};
+
+const handleAuthError = (error: unknown): Response | null => {
+  if (error instanceof SupabaseAuthError) {
+    return error.status >= 500
+      ? serverError(error.message, error.status)
+      : unauthorized(error.message);
+  }
+  if (error instanceof McpTokenCryptoError) {
+    return serverError(error.message, 500);
+  }
+  return null;
+};
+
+export const handleCreateMcpToken = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureSupabaseUser(request, env);
+    const body = await parseBody(request);
+    const name = normalizeName(body.name);
+    const scopes = normalizeScopes(body.scopes);
+    const expiresAt = normalizeExpiresAt(body.expiresInDays);
+    const token = generateMcpToken();
+    const tokenHash = await hashMcpToken(token, env.MCP_TOKEN_HASH_PEPPER);
+    const row = await createMcpTokenRecord(env, {
+      userId: auth.userId,
+      name,
+      tokenHash,
+      scopes,
+      expiresAt,
+    });
+
+    return jsonResponse({ token, mcpToken: toPublicMcpToken(row) }, 201);
+  } catch (error) {
+    const authError = handleAuthError(error);
+    if (authError) return authError;
+    if (error instanceof RequestValidationError) return badRequest(error.message);
+    if (error instanceof Error) return serverError(error.message);
+    return serverError('Unknown error');
+  }
+};
+
+export const handleListMcpTokens = async (request: Request, env: Env): Promise<Response> => {
+  try {
+    const auth = await ensureSupabaseUser(request, env);
+    const rows = await listMcpTokenRecords(env, auth.userId);
+    return jsonResponse({ tokens: rows.map(toPublicMcpToken) });
+  } catch (error) {
+    const authError = handleAuthError(error);
+    if (authError) return authError;
+    if (error instanceof Error) return serverError(error.message);
+    return serverError('Unknown error');
+  }
+};
+
+export const handleRevokeMcpToken = async (
+  request: Request,
+  env: Env,
+  tokenId: string,
+): Promise<Response> => {
+  try {
+    const auth = await ensureSupabaseUser(request, env);
+    const row = await revokeMcpTokenRecord(env, auth.userId, tokenId);
+    if (!row) {
+      return jsonResponse({ status: 'not_found' }, 404);
+    }
+    return jsonResponse({ token: toPublicMcpToken(row) });
+  } catch (error) {
+    const authError = handleAuthError(error);
+    if (authError) return authError;
+    if (error instanceof Error) return serverError(error.message);
+    return serverError('Unknown error');
+  }
+};

--- a/api/src/handlers/syncSession.ts
+++ b/api/src/handlers/syncSession.ts
@@ -238,9 +238,17 @@ export const handleSyncSession = async (request: Request, env: Env): Promise<Res
     return unauthorized('Invalid token');
   }
 
+  return syncSessionForUser(env, auth.userId, payload);
+};
+
+export const syncSessionForUser = async (
+  env: Env,
+  userId: string,
+  payload: SyncRequestBody,
+): Promise<Response> => {
   let connection;
   try {
-    connection = await getConnectionByUser(env, auth.userId);
+    connection = await getConnectionByUser(env, userId);
   } catch (error) {
     if (error instanceof SupabaseRepositoryError) {
       return serverError(error.message, error.status >= 500 ? 502 : error.status);

--- a/api/src/handlers/timeTracker.ts
+++ b/api/src/handlers/timeTracker.ts
@@ -8,6 +8,7 @@ import { badRequest, conflict, jsonResponse, serverError, unauthorized } from '.
 import {
   getRunningState,
   insertSession,
+  listSessions,
   TimeTrackerRepositoryError,
   upsertRunningState,
 } from '../repositories/timeTracker';
@@ -18,7 +19,9 @@ import type {
   RunningSessionStatePayload,
   RunningSessionStopRequest,
   RunningSessionUpdateRequest,
+  TimeTrackerSessionListRequest,
   TimeTrackerSessionPayload,
+  TimeTrackerSessionRecordRequest,
 } from '../types';
 import { syncSessionForUser } from './syncSession';
 
@@ -87,6 +90,30 @@ const validateOptionalString = (value: unknown, field: string): string | null | 
   return trimmed.length > 0 ? trimmed : null;
 };
 
+const validateOptionalTags = (value: unknown, field: string): string[] | undefined => {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((tag) => typeof tag !== 'string')) {
+    throw new HttpResponseError(badRequest(`${field} must be an array of strings`));
+  }
+  return value.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+};
+
+const parseDateField = (value: unknown, field: string): string => {
+  if (typeof value === 'number' || typeof value === 'string') {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      throw new HttpResponseError(badRequest(`${field} must be a valid date string or timestamp`));
+    }
+    return date.toISOString();
+  }
+  throw new HttpResponseError(badRequest(`${field} must be a date string or timestamp`));
+};
+
+const parseOptionalDateField = (value: unknown, field: string): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  return parseDateField(value, field);
+};
+
 const validateDraft = (draft: unknown): RunningSessionDraftPayload => {
   const value = asObject(draft);
   if (!value) {
@@ -96,11 +123,6 @@ const validateDraft = (draft: unknown): RunningSessionDraftPayload => {
   const startedAt = validateString(value.startedAt, 'draft.startedAt');
   if (Number.isNaN(new Date(startedAt).getTime())) {
     throw new HttpResponseError(badRequest('draft.startedAt must be a valid date string'));
-  }
-
-  const tags = value.tags;
-  if (tags !== undefined && (!Array.isArray(tags) || tags.some((tag) => typeof tag !== 'string'))) {
-    throw new HttpResponseError(badRequest('draft.tags must be an array of strings'));
   }
 
   const normalized: RunningSessionDraftPayload = {
@@ -117,11 +139,22 @@ const validateDraft = (draft: unknown): RunningSessionDraftPayload => {
   if (intensity !== undefined) normalized.intensity = intensity;
   const notes = validateOptionalString(value.notes, 'draft.notes');
   if (notes !== undefined) normalized.notes = notes;
-  if (Array.isArray(tags)) {
-    normalized.tags = tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
-  }
+  const tags = validateOptionalTags(value.tags, 'draft.tags');
+  if (tags !== undefined) normalized.tags = tags;
 
   return normalized;
+};
+
+const validateListLimit = (value: unknown): number => {
+  if (value === undefined || value === null) return 10;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new HttpResponseError(badRequest('limit must be a number'));
+  }
+  const limit = Math.floor(value);
+  if (limit < 1 || limit > 50) {
+    throw new HttpResponseError(badRequest('limit must be between 1 and 50'));
+  }
+  return limit;
 };
 
 const validateElapsedSeconds = (elapsedSeconds: unknown): number => {
@@ -195,6 +228,87 @@ const buildCompletedSession = (
   if (draft.intensity) session.intensity = draft.intensity;
 
   return session;
+};
+
+const withLiveElapsedSeconds = (state: RunningSessionStatePayload): RunningSessionStatePayload => {
+  if (state.status !== 'running') {
+    return state;
+  }
+  const startedAtMs = new Date(state.draft.startedAt).getTime();
+  if (Number.isNaN(startedAtMs)) {
+    return state;
+  }
+  return {
+    ...state,
+    elapsedSeconds: Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000)),
+  };
+};
+
+const applyStopOverrides = (
+  draft: RunningSessionDraftPayload,
+  payload: RunningSessionStopRequest,
+): RunningSessionDraftPayload => {
+  const nextDraft: RunningSessionDraftPayload = { ...draft };
+
+  if (payload.title !== undefined) {
+    nextDraft.title = validateString(payload.title, 'title');
+  }
+
+  const project = validateOptionalString(payload.project, 'project');
+  if (project !== undefined) nextDraft.project = project;
+  const notes = validateOptionalString(payload.notes, 'notes');
+  if (notes !== undefined) nextDraft.notes = notes;
+  const skill = validateOptionalString(payload.skill, 'skill');
+  if (skill !== undefined) nextDraft.skill = skill;
+  const intensity = validateOptionalString(payload.intensity, 'intensity');
+  if (intensity !== undefined) nextDraft.intensity = intensity;
+  const tags = validateOptionalTags(payload.tags, 'tags');
+  if (tags !== undefined) nextDraft.tags = tags;
+
+  return nextDraft;
+};
+
+const buildRecordSession = (
+  payload: TimeTrackerSessionRecordRequest,
+): { session: TimeTrackerSessionPayload; warnings: string[]; dryRun: boolean } => {
+  const title = validateString(payload.title, 'title');
+  const startedAt = parseDateField(payload.startedAt, 'startedAt');
+  const endedAt = parseDateField(payload.endedAt, 'endedAt');
+  const startedAtMs = new Date(startedAt).getTime();
+  const endedAtMs = new Date(endedAt).getTime();
+  if (startedAtMs >= endedAtMs) {
+    throw new HttpResponseError(badRequest('startedAt must be before endedAt'));
+  }
+  if (endedAtMs > Date.now()) {
+    throw new HttpResponseError(badRequest('endedAt must not be in the future'));
+  }
+
+  const durationSeconds = Math.floor((endedAtMs - startedAtMs) / 1000);
+  const warnings: string[] = [];
+  if (durationSeconds > 12 * 60 * 60) {
+    warnings.push('duration_exceeds_12_hours');
+  }
+
+  const session: TimeTrackerSessionPayload = {
+    id: validateOptionalString(payload.id, 'id') ?? crypto.randomUUID(),
+    title,
+    startedAt,
+    endedAt,
+    durationSeconds,
+  };
+
+  const project = validateOptionalString(payload.project, 'project');
+  if (project !== undefined) session.project = project;
+  const notes = validateOptionalString(payload.notes, 'notes');
+  if (notes !== undefined) session.notes = notes;
+  const skill = validateOptionalString(payload.skill, 'skill');
+  if (skill !== undefined) session.skill = skill;
+  const intensity = validateOptionalString(payload.intensity, 'intensity');
+  if (intensity !== undefined) session.intensity = intensity;
+  const tags = validateOptionalTags(payload.tags, 'tags');
+  if (tags !== undefined) session.tags = tags;
+
+  return { session, warnings, dryRun: payload.dryRun === true };
 };
 
 type CompletedSessionSyncResult =
@@ -313,7 +427,23 @@ export const getRunningStateForUser = async (
   userId: string,
 ): Promise<TimeTrackerOperationResult> => {
   const state = (await getRunningState(env, userId)) ?? idleState;
-  return { body: { state } };
+  return { body: { state: withLiveElapsedSeconds(state) } };
+};
+
+export const listSessionsForUser = async (
+  env: Env,
+  userId: string,
+  payload: TimeTrackerSessionListRequest,
+): Promise<TimeTrackerOperationResult> => {
+  const sessions = await listSessions(env, userId, {
+    limit: validateListLimit(payload.limit),
+    from: parseOptionalDateField(payload.from, 'from'),
+    to: parseOptionalDateField(payload.to, 'to'),
+    query: validateOptionalString(payload.query, 'query') ?? undefined,
+    project: validateOptionalString(payload.project, 'project') ?? undefined,
+    tags: validateOptionalTags(payload.tags, 'tags'),
+  });
+  return { body: { sessions } };
 };
 
 export const startRunningSessionForUser = async (
@@ -370,12 +500,34 @@ export const stopRunningSessionForUser = async (
   ensureSessionIdMatches(currentState, payload.id);
 
   const stoppedAt = parseStoppedAt(payload.stoppedAt);
-  const session = buildCompletedSession(currentState.draft, stoppedAt);
+  const session = buildCompletedSession(applyStopOverrides(currentState.draft, payload), stoppedAt);
   const savedSession = await insertSession(env, userId, session);
   const savedState = await upsertRunningState(env, userId, idleState);
   const sync = await syncCompletedSession(env, userId, savedSession);
 
   return { body: { session: savedSession, state: savedState, sync } };
+};
+
+export const recordSessionForUser = async (
+  env: Env,
+  userId: string,
+  payload: TimeTrackerSessionRecordRequest,
+): Promise<TimeTrackerOperationResult> => {
+  const { session, warnings, dryRun } = buildRecordSession(payload);
+  if (dryRun) {
+    return {
+      body: {
+        session,
+        dryRun: true,
+        warnings,
+        sync: { status: 'skipped', reason: 'dry_run' },
+      },
+    };
+  }
+
+  const savedSession = await insertSession(env, userId, session);
+  const sync = await syncCompletedSession(env, userId, savedSession);
+  return { body: { session: savedSession, warnings, sync }, status: 201 };
 };
 
 export const cancelRunningSessionForUser = async (

--- a/api/src/handlers/timeTracker.ts
+++ b/api/src/handlers/timeTracker.ts
@@ -14,12 +14,13 @@ import {
 import type {
   RunningSessionCancelRequest,
   RunningSessionDraftPayload,
+  RunningSessionStartRequest,
   RunningSessionStatePayload,
   RunningSessionStopRequest,
   RunningSessionUpdateRequest,
   TimeTrackerSessionPayload,
 } from '../types';
-import { handleSyncSession } from './syncSession';
+import { syncSessionForUser } from './syncSession';
 
 class HttpResponseError extends Error {
   readonly response: Response;
@@ -242,32 +243,21 @@ const describeSyncError = (detail: unknown, fallback: string): string => {
   return fallback;
 };
 
+export type TimeTrackerOperationResult = {
+  body: unknown;
+  status?: number;
+};
+
 const syncCompletedSession = async (
-  request: Request,
   env: Env,
+  userId: string,
   session: TimeTrackerSessionPayload,
 ): Promise<CompletedSessionSyncResult> => {
-  const token = extractBearerToken(request);
-  if (!token) {
-    return { status: 'skipped', reason: 'Bearer token is required' };
-  }
-
   try {
-    const syncUrl = new URL('/integrations/google/sync', request.url);
-    const syncResponse = await handleSyncSession(
-      new Request(syncUrl.toString(), {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          session,
-          source: 'time-tracker-worker-api',
-        }),
-      }),
-      env,
-    );
+    const syncResponse = await syncSessionForUser(env, userId, {
+      session,
+      source: 'time-tracker-worker-api',
+    });
     const detail = await readResponseBody(syncResponse);
 
     if (syncResponse.ok) {
@@ -318,12 +308,99 @@ const handleError = (responseOrError: unknown): Response => {
   return serverError('Unknown error', 500);
 };
 
+export const getRunningStateForUser = async (
+  env: Env,
+  userId: string,
+): Promise<TimeTrackerOperationResult> => {
+  const state = (await getRunningState(env, userId)) ?? idleState;
+  return { body: { state } };
+};
+
+export const startRunningSessionForUser = async (
+  env: Env,
+  userId: string,
+  payload: { draft?: unknown },
+): Promise<TimeTrackerOperationResult> => {
+  const draft = validateDraft(payload.draft);
+  const currentState = await getRunningState(env, userId);
+
+  if (currentState?.status === 'running') {
+    if (currentState.draft.id === draft.id) {
+      return { body: { state: currentState } };
+    }
+    throw new HttpResponseError(conflict('already_running', 'A running session already exists'));
+  }
+
+  const state: RunningSessionStatePayload = {
+    status: 'running',
+    draft,
+    elapsedSeconds: 0,
+  };
+  const savedState = await upsertRunningState(env, userId, state);
+
+  return { body: { state: savedState }, status: 201 };
+};
+
+export const updateRunningSessionForUser = async (
+  env: Env,
+  userId: string,
+  payload: RunningSessionUpdateRequest,
+): Promise<TimeTrackerOperationResult> => {
+  const draft = validateDraft(payload.draft);
+  const elapsedSeconds = validateElapsedSeconds(payload.elapsedSeconds);
+  const currentState = requireCurrentRunning(await getRunningState(env, userId));
+  ensureSessionIdMatches(currentState, draft.id);
+
+  const state: RunningSessionStatePayload = {
+    status: 'running',
+    draft,
+    elapsedSeconds,
+  };
+  const savedState = await upsertRunningState(env, userId, state);
+
+  return { body: { state: savedState } };
+};
+
+export const stopRunningSessionForUser = async (
+  env: Env,
+  userId: string,
+  payload: RunningSessionStopRequest,
+): Promise<TimeTrackerOperationResult> => {
+  const currentState = requireCurrentRunning(await getRunningState(env, userId));
+  ensureSessionIdMatches(currentState, payload.id);
+
+  const stoppedAt = parseStoppedAt(payload.stoppedAt);
+  const session = buildCompletedSession(currentState.draft, stoppedAt);
+  const savedSession = await insertSession(env, userId, session);
+  const savedState = await upsertRunningState(env, userId, idleState);
+  const sync = await syncCompletedSession(env, userId, savedSession);
+
+  return { body: { session: savedSession, state: savedState, sync } };
+};
+
+export const cancelRunningSessionForUser = async (
+  env: Env,
+  userId: string,
+  payload: RunningSessionCancelRequest,
+): Promise<TimeTrackerOperationResult> => {
+  const currentState = await getRunningState(env, userId);
+
+  if (!currentState || currentState.status === 'idle') {
+    return { body: { state: idleState } };
+  }
+  ensureSessionIdMatches(currentState, payload.id);
+
+  const savedState = await upsertRunningState(env, userId, idleState);
+
+  return { body: { state: savedState } };
+};
+
 export const handleGetRunningState = async (request: Request, env: Env): Promise<Response> => {
   try {
     const auth = await ensureAuthorized(request, env);
-    const state = (await getRunningState(env, auth.userId)) ?? idleState;
+    const result = await getRunningStateForUser(env, auth.userId);
 
-    return jsonResponse({ state });
+    return jsonResponse(result.body, result.status);
   } catch (responseOrError) {
     return handleError(responseOrError);
   }
@@ -332,25 +409,10 @@ export const handleGetRunningState = async (request: Request, env: Env): Promise
 export const handleStartRunningSession = async (request: Request, env: Env): Promise<Response> => {
   try {
     const auth = await ensureAuthorized(request, env);
-    const payload = await parseJson<{ draft?: unknown }>(request);
-    const draft = validateDraft(payload.draft);
-    const currentState = await getRunningState(env, auth.userId);
+    const payload = await parseJson<RunningSessionStartRequest>(request);
+    const result = await startRunningSessionForUser(env, auth.userId, payload);
 
-    if (currentState?.status === 'running') {
-      if (currentState.draft.id === draft.id) {
-        return jsonResponse({ state: currentState });
-      }
-      throw new HttpResponseError(conflict('already_running', 'A running session already exists'));
-    }
-
-    const state: RunningSessionStatePayload = {
-      status: 'running',
-      draft,
-      elapsedSeconds: 0,
-    };
-    const savedState = await upsertRunningState(env, auth.userId, state);
-
-    return jsonResponse({ state: savedState }, 201);
+    return jsonResponse(result.body, result.status);
   } catch (responseOrError) {
     return handleError(responseOrError);
   }
@@ -360,19 +422,9 @@ export const handleUpdateRunningSession = async (request: Request, env: Env): Pr
   try {
     const auth = await ensureAuthorized(request, env);
     const payload = await parseJson<RunningSessionUpdateRequest>(request);
-    const draft = validateDraft(payload.draft);
-    const elapsedSeconds = validateElapsedSeconds(payload.elapsedSeconds);
-    const currentState = requireCurrentRunning(await getRunningState(env, auth.userId));
-    ensureSessionIdMatches(currentState, draft.id);
+    const result = await updateRunningSessionForUser(env, auth.userId, payload);
 
-    const state: RunningSessionStatePayload = {
-      status: 'running',
-      draft,
-      elapsedSeconds,
-    };
-    const savedState = await upsertRunningState(env, auth.userId, state);
-
-    return jsonResponse({ state: savedState });
+    return jsonResponse(result.body, result.status);
   } catch (responseOrError) {
     return handleError(responseOrError);
   }
@@ -382,16 +434,9 @@ export const handleStopRunningSession = async (request: Request, env: Env): Prom
   try {
     const auth = await ensureAuthorized(request, env);
     const payload = await parseJson<RunningSessionStopRequest>(request);
-    const currentState = requireCurrentRunning(await getRunningState(env, auth.userId));
-    ensureSessionIdMatches(currentState, payload.id);
+    const result = await stopRunningSessionForUser(env, auth.userId, payload);
 
-    const stoppedAt = parseStoppedAt(payload.stoppedAt);
-    const session = buildCompletedSession(currentState.draft, stoppedAt);
-    const savedSession = await insertSession(env, auth.userId, session);
-    const savedState = await upsertRunningState(env, auth.userId, idleState);
-    const sync = await syncCompletedSession(request, env, savedSession);
-
-    return jsonResponse({ session: savedSession, state: savedState, sync });
+    return jsonResponse(result.body, result.status);
   } catch (responseOrError) {
     return handleError(responseOrError);
   }
@@ -401,16 +446,9 @@ export const handleCancelRunningSession = async (request: Request, env: Env): Pr
   try {
     const auth = await ensureAuthorized(request, env);
     const payload = await parseJson<RunningSessionCancelRequest>(request);
-    const currentState = await getRunningState(env, auth.userId);
+    const result = await cancelRunningSessionForUser(env, auth.userId, payload);
 
-    if (!currentState || currentState.status === 'idle') {
-      return jsonResponse({ state: idleState });
-    }
-    ensureSessionIdMatches(currentState, payload.id);
-
-    const savedState = await upsertRunningState(env, auth.userId, idleState);
-
-    return jsonResponse({ state: savedState });
+    return jsonResponse(result.body, result.status);
   } catch (responseOrError) {
     return handleError(responseOrError);
   }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,4 +1,10 @@
 import type { Env } from './env';
+import { handleMcp } from './handlers/mcp';
+import {
+  handleCreateMcpToken,
+  handleListMcpTokens,
+  handleRevokeMcpToken,
+} from './handlers/mcpTokens';
 import { handleOauthCallback, handleOauthRevoke, handleOauthStart } from './handlers/oauth';
 import {
   handleRunningSessionCancel,
@@ -37,6 +43,8 @@ const ROUTES = {
   TIME_TRACKER_RUNNING_UPDATE: '/time-tracker/running/update',
   TIME_TRACKER_RUNNING_STOP: '/time-tracker/running/stop',
   TIME_TRACKER_RUNNING_CANCEL: '/time-tracker/running/cancel',
+  MCP: '/mcp',
+  MCP_TOKENS: '/mcp/tokens',
 } as const;
 
 const withCors = (response: Response, request: Request): Response => {
@@ -133,6 +141,23 @@ export default {
 
     if (request.method === 'POST' && url.pathname === ROUTES.TIME_TRACKER_RUNNING_CANCEL) {
       return respond(handleCancelRunningSession(request, env), request);
+    }
+
+    if (request.method === 'POST' && url.pathname === ROUTES.MCP) {
+      return respond(handleMcp(request, env), request);
+    }
+
+    if (request.method === 'GET' && url.pathname === ROUTES.MCP_TOKENS) {
+      return respond(handleListMcpTokens(request, env), request);
+    }
+
+    if (request.method === 'POST' && url.pathname === ROUTES.MCP_TOKENS) {
+      return respond(handleCreateMcpToken(request, env), request);
+    }
+
+    if (request.method === 'DELETE' && url.pathname.startsWith(`${ROUTES.MCP_TOKENS}/`)) {
+      const tokenId = decodeURIComponent(url.pathname.slice(`${ROUTES.MCP_TOKENS}/`.length));
+      return respond(handleRevokeMcpToken(request, env, tokenId), request);
     }
 
     return withCors(new Response('Not Found', { status: 404 }), request);

--- a/api/src/repositories/__tests__/mcpTokens.test.ts
+++ b/api/src/repositories/__tests__/mcpTokens.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMcpTokenRecord,
+  findMcpTokenRecordByHash,
+  listMcpTokenRecords,
+  revokeMcpTokenRecord,
+  touchMcpTokenRecord,
+} from '../mcpTokens';
+
+const env = {
+  SUPABASE_URL: 'https://supabase.test',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  GOOGLE_CLIENT_ID: '',
+  GOOGLE_CLIENT_SECRET: '',
+  GOOGLE_REDIRECT_URI: '',
+  MCP_TOKEN_HASH_PEPPER: 'pepper',
+} as const;
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+describe('MCP token Supabase repository', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('creates token rows without returning raw token material to the database', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'token-1',
+          user_id: 'user-1',
+          name: 'Codex',
+          token_hash: 'hash',
+          scopes: ['time-tracker:read', 'time-tracker:write'],
+          expires_at: '2026-08-01T00:00:00.000Z',
+          revoked_at: null,
+          last_used_at: null,
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+        },
+      ]),
+    );
+
+    await createMcpTokenRecord(env, {
+      userId: 'user-1',
+      name: 'Codex',
+      tokenHash: 'hash',
+      scopes: ['time-tracker:read', 'time-tracker:write'],
+      expiresAt: '2026-08-01T00:00:00.000Z',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(parsedUrl.pathname).toBe('/rest/v1/forge_mcp_tokens');
+    expect(init).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(init.body))).toEqual(
+      expect.objectContaining({
+        user_id: 'user-1',
+        name: 'Codex',
+        token_hash: 'hash',
+        scopes: ['time-tracker:read', 'time-tracker:write'],
+      }),
+    );
+    expect(String(init.body)).not.toContain('forge_mcp_');
+  });
+
+  it('lists only tokens owned by the verified user', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await listMcpTokenRecords(env, 'user-1');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(init).toMatchObject({ method: 'GET' });
+    expect(parsedUrl.searchParams.get('user_id')).toBe('eq.user-1');
+    expect(parsedUrl.searchParams.get('order')).toBe('created_at.desc');
+  });
+
+  it('looks up token rows by hash only', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await findMcpTokenRecordByHash(env, 'hash');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(init).toMatchObject({ method: 'GET' });
+    expect(parsedUrl.searchParams.get('token_hash')).toBe('eq.hash');
+    expect(parsedUrl.searchParams.toString()).not.toContain('forge_mcp_');
+  });
+
+  it('revokes only tokens owned by the verified user', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await revokeMcpTokenRecord(env, 'user-1', 'token-1');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(init).toMatchObject({ method: 'PATCH' });
+    expect(parsedUrl.searchParams.get('id')).toBe('eq.token-1');
+    expect(parsedUrl.searchParams.get('user_id')).toBe('eq.user-1');
+    expect(JSON.parse(String(init.body))).toHaveProperty('revoked_at');
+  });
+
+  it('updates last_used_at without changing token secrets', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await touchMcpTokenRecord(env, 'token-1');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(init).toMatchObject({ method: 'PATCH' });
+    expect(parsedUrl.searchParams.get('id')).toBe('eq.token-1');
+    expect(JSON.parse(String(init.body))).toHaveProperty('last_used_at');
+    expect(String(init.body)).not.toContain('token_hash');
+  });
+});

--- a/api/src/repositories/__tests__/timeTracker.test.ts
+++ b/api/src/repositories/__tests__/timeTracker.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getRunningState, insertSession, upsertRunningState } from '../timeTracker';
+import { getRunningState, insertSession, listSessions, upsertRunningState } from '../timeTracker';
 
 const env = {
   SUPABASE_URL: 'https://supabase.test',
@@ -137,5 +137,62 @@ describe('time tracker Supabase repository', () => {
       duration_seconds: 300,
       project: 'Forge',
     });
+  });
+
+  it('lists recent sessions with verified-user and bounded filters', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'session-1',
+          title: 'Focus',
+          started_at: '2026-04-30T00:00:00.000Z',
+          ended_at: '2026-04-30T00:05:00.000Z',
+          duration_seconds: 300,
+          project: 'Forge',
+          notes: null,
+          tags: ['mcp'],
+        },
+      ]),
+    );
+
+    const sessions = await listSessions(env, 'user-1', {
+      limit: 5,
+      from: '2026-04-01T00:00:00.000Z',
+      to: '2026-05-01T00:00:00.000Z',
+      query: 'Focus',
+      project: 'Forge',
+      tags: ['mcp'],
+    });
+
+    expect(sessions).toEqual([
+      {
+        id: 'session-1',
+        title: 'Focus',
+        startedAt: '2026-04-30T00:00:00.000Z',
+        endedAt: '2026-04-30T00:05:00.000Z',
+        durationSeconds: 300,
+        project: 'Forge',
+        tags: ['mcp'],
+      },
+    ]);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(String(url));
+    expect(parsedUrl.pathname).toBe('/rest/v1/time_tracker_sessions');
+    expect(parsedUrl.searchParams.get('select')).toBe(
+      'id,title,started_at,ended_at,duration_seconds,tags,project,notes',
+    );
+    expect(parsedUrl.searchParams.get('user_id')).toBe('eq.user-1');
+    expect(parsedUrl.searchParams.get('order')).toBe('started_at.desc');
+    expect(parsedUrl.searchParams.get('limit')).toBe('5');
+    expect(parsedUrl.searchParams.get('and')).toBe(
+      '(started_at.gte.2026-04-01T00:00:00.000Z,started_at.lte.2026-05-01T00:00:00.000Z)',
+    );
+    expect(parsedUrl.searchParams.get('or')).toBe(
+      '(title.ilike.*Focus*,project.ilike.*Focus*,notes.ilike.*Focus*)',
+    );
+    expect(parsedUrl.searchParams.get('project')).toBe('eq.Forge');
+    expect(parsedUrl.searchParams.get('tags')).toBe('cs.{mcp}');
+    expect(init).toMatchObject({ method: 'GET' });
   });
 });

--- a/api/src/repositories/budgets.ts
+++ b/api/src/repositories/budgets.ts
@@ -1,0 +1,68 @@
+import type { Env } from '../env';
+import type { BudgetPayload, BudgetUpsertRequest } from '../types';
+import { supabaseRequest } from './supabaseRest';
+
+const TABLE = 'time_tracker_budgets';
+const SELECT = 'id,tag,label,weekday_minutes,effective_from,effective_to';
+
+type BudgetRow = {
+  id: string;
+  tag: string;
+  label: string | null;
+  weekday_minutes: number[] | null;
+  effective_from: string;
+  effective_to: string | null;
+};
+
+const mapRow = (row: BudgetRow): BudgetPayload => ({
+  id: row.id,
+  tag: row.tag,
+  label: row.label,
+  weekdayMinutes:
+    Array.isArray(row.weekday_minutes) && row.weekday_minutes.length === 7
+      ? row.weekday_minutes
+      : [0, 0, 0, 0, 0, 0, 0],
+  effectiveFrom: row.effective_from,
+  effectiveTo: row.effective_to,
+});
+
+export const listBudgets = async (env: Env, userId: string): Promise<BudgetPayload[]> => {
+  const rows = await supabaseRequest<BudgetRow[]>(env, 'GET', TABLE, {
+    searchParams: {
+      select: SELECT,
+      user_id: `eq.${userId}`,
+      order: 'effective_from.desc',
+    },
+  });
+  return rows.map(mapRow);
+};
+
+export const upsertBudget = async (
+  env: Env,
+  userId: string,
+  budget: BudgetPayload,
+): Promise<BudgetPayload> => {
+  const rows = await supabaseRequest<BudgetRow[]>(env, 'POST', TABLE, {
+    body: {
+      id: budget.id,
+      user_id: userId,
+      tag: budget.tag,
+      label: budget.label ?? null,
+      weekday_minutes: budget.weekdayMinutes,
+      effective_from: budget.effectiveFrom,
+      effective_to: budget.effectiveTo ?? null,
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: { on_conflict: 'id', select: SELECT },
+    prefer: 'resolution=merge-duplicates,return=representation',
+  });
+  return mapRow(rows[0]);
+};
+
+export const deleteBudget = async (env: Env, userId: string, id: string): Promise<void> => {
+  await supabaseRequest(env, 'DELETE', TABLE, {
+    searchParams: { user_id: `eq.${userId}`, id: `eq.${id}` },
+  });
+};
+
+export type { BudgetUpsertRequest };

--- a/api/src/repositories/dailyMetrics.ts
+++ b/api/src/repositories/dailyMetrics.ts
@@ -1,0 +1,163 @@
+import type { Env } from '../env';
+import type {
+  MetricDefinitionPayload,
+  MetricEntryPayload,
+  MetricKind,
+  MetricValuePayload,
+} from '../types';
+import { sanitizePostgrestSearchTerm, supabaseRequest } from './supabaseRest';
+
+const DEFINITIONS_TABLE = 'daily_metric_definitions';
+const ENTRIES_TABLE = 'daily_metric_entries';
+const DEFINITION_SELECT = 'id,name,kind,unit,options,target_number,display_order,archived_at';
+const ENTRY_SELECT = 'id,metric_id,entry_date,value';
+
+type DefinitionRow = {
+  id: string;
+  name: string;
+  kind: MetricKind;
+  unit: string | null;
+  options: MetricDefinitionPayload['options'];
+  target_number: number | null;
+  display_order: number | null;
+  archived_at: string | null;
+};
+
+type EntryRow = {
+  id: string;
+  metric_id: string;
+  entry_date: string;
+  value: MetricValuePayload;
+};
+
+const mapDefinition = (row: DefinitionRow): MetricDefinitionPayload => ({
+  id: row.id,
+  name: row.name,
+  kind: row.kind,
+  unit: row.unit,
+  options: row.options ?? null,
+  targetNumber: row.target_number,
+  displayOrder: row.display_order ?? 0,
+  archivedAt: row.archived_at,
+});
+
+const mapEntry = (row: EntryRow): MetricEntryPayload => ({
+  id: row.id,
+  metricId: row.metric_id,
+  entryDate: row.entry_date,
+  value: row.value,
+});
+
+export const listDefinitions = async (
+  env: Env,
+  userId: string,
+): Promise<MetricDefinitionPayload[]> => {
+  const rows = await supabaseRequest<DefinitionRow[]>(env, 'GET', DEFINITIONS_TABLE, {
+    searchParams: {
+      select: DEFINITION_SELECT,
+      user_id: `eq.${userId}`,
+      archived_at: 'is.null',
+      order: 'display_order.asc',
+    },
+  });
+  return rows.map(mapDefinition);
+};
+
+export const findDefinitionByName = async (
+  env: Env,
+  userId: string,
+  name: string,
+): Promise<MetricDefinitionPayload | null> => {
+  const safe = sanitizePostgrestSearchTerm(name);
+  const rows = await supabaseRequest<DefinitionRow[]>(env, 'GET', DEFINITIONS_TABLE, {
+    searchParams: {
+      select: DEFINITION_SELECT,
+      user_id: `eq.${userId}`,
+      name: `eq.${safe}`,
+      archived_at: 'is.null',
+      limit: '1',
+    },
+  });
+  return rows.length > 0 ? mapDefinition(rows[0]) : null;
+};
+
+export const upsertDefinition = async (
+  env: Env,
+  userId: string,
+  definition: MetricDefinitionPayload,
+): Promise<MetricDefinitionPayload> => {
+  const rows = await supabaseRequest<DefinitionRow[]>(env, 'POST', DEFINITIONS_TABLE, {
+    body: {
+      id: definition.id,
+      user_id: userId,
+      name: definition.name,
+      kind: definition.kind,
+      unit: definition.unit ?? null,
+      options: definition.options ?? null,
+      target_number: definition.targetNumber ?? null,
+      display_order: definition.displayOrder,
+      archived_at: definition.archivedAt ?? null,
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: { on_conflict: 'id', select: DEFINITION_SELECT },
+    prefer: 'resolution=merge-duplicates,return=representation',
+  });
+  return mapDefinition(rows[0]);
+};
+
+export const deleteDefinition = async (env: Env, userId: string, id: string): Promise<void> => {
+  await supabaseRequest(env, 'DELETE', DEFINITIONS_TABLE, {
+    searchParams: { user_id: `eq.${userId}`, id: `eq.${id}` },
+  });
+};
+
+export const listEntries = async (
+  env: Env,
+  userId: string,
+  fromKey: string,
+  toKey: string,
+): Promise<MetricEntryPayload[]> => {
+  const rows = await supabaseRequest<EntryRow[]>(env, 'GET', ENTRIES_TABLE, {
+    searchParams: {
+      select: ENTRY_SELECT,
+      user_id: `eq.${userId}`,
+      and: `(entry_date.gte.${fromKey},entry_date.lte.${toKey})`,
+      order: 'entry_date.desc',
+    },
+  });
+  return rows.map(mapEntry);
+};
+
+export const upsertEntry = async (
+  env: Env,
+  userId: string,
+  entry: { metricId: string; entryDate: string; value: MetricValuePayload },
+): Promise<MetricEntryPayload> => {
+  const rows = await supabaseRequest<EntryRow[]>(env, 'POST', ENTRIES_TABLE, {
+    body: {
+      user_id: userId,
+      metric_id: entry.metricId,
+      entry_date: entry.entryDate,
+      value: entry.value,
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: { on_conflict: 'user_id,metric_id,entry_date', select: ENTRY_SELECT },
+    prefer: 'resolution=merge-duplicates,return=representation',
+  });
+  return mapEntry(rows[0]);
+};
+
+export const deleteEntry = async (
+  env: Env,
+  userId: string,
+  metricId: string,
+  entryDate: string,
+): Promise<void> => {
+  await supabaseRequest(env, 'DELETE', ENTRIES_TABLE, {
+    searchParams: {
+      user_id: `eq.${userId}`,
+      metric_id: `eq.${metricId}`,
+      entry_date: `eq.${entryDate}`,
+    },
+  });
+};

--- a/api/src/repositories/mcpTokens.ts
+++ b/api/src/repositories/mcpTokens.ts
@@ -1,0 +1,210 @@
+import type { Env } from '../env';
+
+export const MCP_TOKEN_SCOPES = ['time-tracker:read', 'time-tracker:write'] as const;
+
+export type McpTokenScope = (typeof MCP_TOKEN_SCOPES)[number];
+
+export type McpTokenRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  token_hash: string;
+  scopes: McpTokenScope[];
+  expires_at: string;
+  revoked_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type McpTokenPublic = {
+  id: string;
+  name: string;
+  scopes: McpTokenScope[];
+  expiresAt: string;
+  revokedAt: string | null;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export class McpTokenRepositoryError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'McpTokenRepositoryError';
+    this.status = status;
+  }
+}
+
+const REST_PREFIX = '/rest/v1';
+const TABLE = 'forge_mcp_tokens';
+
+const ensureConfig = (env: Env) => {
+  if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new McpTokenRepositoryError('Supabase REST configuration is missing', 500);
+  }
+};
+
+const resolveRestUrl = (env: Env, path: string, searchParams?: Record<string, string>): URL => {
+  const url = new URL(`${REST_PREFIX}/${path}`, env.SUPABASE_URL);
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url;
+};
+
+const restHeaders = (env: Env, prefer?: string): HeadersInit => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+    apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+    'Content-Type': 'application/json',
+  };
+  if (prefer) {
+    headers.Prefer = prefer;
+  }
+  return headers;
+};
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+  const text = await response.text();
+  return text as unknown as T;
+};
+
+const request = async <T>(
+  env: Env,
+  method: string,
+  path: string,
+  options: {
+    searchParams?: Record<string, string>;
+    body?: unknown;
+    prefer?: string;
+  } = {},
+): Promise<T> => {
+  ensureConfig(env);
+  const url = resolveRestUrl(env, path, options.searchParams);
+  const response = await fetch(url, {
+    method,
+    headers: restHeaders(env, options.prefer),
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    let detail: unknown;
+    try {
+      detail = await response.json();
+    } catch {
+      detail = await response.text();
+    }
+    throw new McpTokenRepositoryError(
+      `Supabase request failed: ${method} ${url.toString()} (${response.status}) ${JSON.stringify(
+        detail,
+      )}`,
+      response.status,
+    );
+  }
+
+  return handleResponse<T>(response);
+};
+
+export const toPublicMcpToken = (row: McpTokenRow): McpTokenPublic => ({
+  id: row.id,
+  name: row.name,
+  scopes: row.scopes,
+  expiresAt: row.expires_at,
+  revokedAt: row.revoked_at,
+  lastUsedAt: row.last_used_at,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+export const createMcpTokenRecord = async (
+  env: Env,
+  input: {
+    userId: string;
+    name: string;
+    tokenHash: string;
+    scopes: McpTokenScope[];
+    expiresAt: string;
+  },
+): Promise<McpTokenRow> => {
+  const rows = await request<McpTokenRow[]>(env, 'POST', TABLE, {
+    body: {
+      user_id: input.userId,
+      name: input.name,
+      token_hash: input.tokenHash,
+      scopes: input.scopes,
+      expires_at: input.expiresAt,
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: { select: '*' },
+    prefer: 'return=representation',
+  });
+
+  return rows[0];
+};
+
+export const listMcpTokenRecords = async (env: Env, userId: string): Promise<McpTokenRow[]> =>
+  request<McpTokenRow[]>(env, 'GET', TABLE, {
+    searchParams: {
+      user_id: `eq.${userId}`,
+      select: '*',
+      order: 'created_at.desc',
+    },
+  });
+
+export const findMcpTokenRecordByHash = async (
+  env: Env,
+  tokenHash: string,
+): Promise<McpTokenRow | null> => {
+  const rows = await request<McpTokenRow[]>(env, 'GET', TABLE, {
+    searchParams: {
+      token_hash: `eq.${tokenHash}`,
+      select: '*',
+      limit: '1',
+    },
+  });
+  return rows.length > 0 ? rows[0] : null;
+};
+
+export const revokeMcpTokenRecord = async (
+  env: Env,
+  userId: string,
+  tokenId: string,
+): Promise<McpTokenRow | null> => {
+  const rows = await request<McpTokenRow[]>(env, 'PATCH', TABLE, {
+    body: {
+      revoked_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: {
+      id: `eq.${tokenId}`,
+      user_id: `eq.${userId}`,
+      select: '*',
+    },
+    prefer: 'return=representation',
+  });
+  return rows.length > 0 ? rows[0] : null;
+};
+
+export const touchMcpTokenRecord = async (env: Env, tokenId: string): Promise<void> => {
+  await request(env, 'PATCH', TABLE, {
+    body: {
+      last_used_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    searchParams: {
+      id: `eq.${tokenId}`,
+    },
+  });
+};

--- a/api/src/repositories/supabaseRest.ts
+++ b/api/src/repositories/supabaseRest.ts
@@ -1,0 +1,95 @@
+import type { Env } from '../env';
+
+const REST_PREFIX = '/rest/v1';
+
+export class SupabaseRestError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'SupabaseRestError';
+    this.status = status;
+  }
+}
+
+const ensureConfig = (env: Env) => {
+  if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new SupabaseRestError('Supabase REST configuration is missing', 500);
+  }
+};
+
+const resolveRestUrl = (env: Env, path: string, searchParams?: Record<string, string>): URL => {
+  const url = new URL(`${REST_PREFIX}/${path}`, env.SUPABASE_URL);
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url;
+};
+
+const restHeaders = (env: Env, prefer?: string): HeadersInit => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+    apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+    'Content-Type': 'application/json',
+  };
+  if (prefer) {
+    headers.Prefer = prefer;
+  }
+  return headers;
+};
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+  const text = await response.text();
+  return text as unknown as T;
+};
+
+/** Supabase REST（service role）への汎用リクエスト。 */
+export const supabaseRequest = async <T>(
+  env: Env,
+  method: string,
+  path: string,
+  options: {
+    searchParams?: Record<string, string>;
+    body?: unknown;
+    prefer?: string;
+  } = {},
+): Promise<T> => {
+  ensureConfig(env);
+  const url = resolveRestUrl(env, path, options.searchParams);
+  const response = await fetch(url, {
+    method,
+    headers: restHeaders(env, options.prefer),
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    let detail: unknown;
+    try {
+      detail = await response.json();
+    } catch {
+      detail = await response.text();
+    }
+    throw new SupabaseRestError(
+      `Supabase request failed: ${method} ${url.toString()} (${response.status}) ${JSON.stringify(detail)}`,
+      response.status,
+    );
+  }
+
+  return handleResponse<T>(response);
+};
+
+/** PostgREST の検索語に使えないよう特殊文字を除去する。 */
+export const sanitizePostgrestSearchTerm = (value: string): string =>
+  value
+    .replace(/[(),{}"]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();

--- a/api/src/repositories/timeTracker.ts
+++ b/api/src/repositories/timeTracker.ts
@@ -18,6 +18,15 @@ type SessionRow = {
   notes: string | null;
 };
 
+export type ListSessionsOptions = {
+  limit: number;
+  from?: string;
+  to?: string;
+  query?: string;
+  project?: string;
+  tags?: string[];
+};
+
 export class TimeTrackerRepositoryError extends Error {
   readonly status: number;
 
@@ -29,6 +38,7 @@ export class TimeTrackerRepositoryError extends Error {
 }
 
 const REST_PREFIX = '/rest/v1';
+const SESSION_SELECT = 'id,title,started_at,ended_at,duration_seconds,tags,project,notes';
 
 const ensureConfig = (env: Env) => {
   if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_ROLE_KEY) {
@@ -140,6 +150,17 @@ const mapSessionRow = (row: SessionRow): TimeTrackerSessionPayload => {
   return session;
 };
 
+const sanitizePostgrestSearchTerm = (value: string): string =>
+  value
+    .replace(/[(),{}"]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const tagsContainFilter = (tags: string[]): string | undefined => {
+  const cleaned = tags.map(sanitizePostgrestSearchTerm).filter((tag) => tag.length > 0);
+  return cleaned.length > 0 ? `cs.{${cleaned.join(',')}}` : undefined;
+};
+
 export const getRunningState = async (
   env: Env,
   userId: string,
@@ -153,6 +174,48 @@ export const getRunningState = async (
   });
 
   return rows.length > 0 ? mapRunningStateRow(rows[0]) : null;
+};
+
+export const listSessions = async (
+  env: Env,
+  userId: string,
+  options: ListSessionsOptions,
+): Promise<TimeTrackerSessionPayload[]> => {
+  const searchParams: Record<string, string> = {
+    select: SESSION_SELECT,
+    user_id: `eq.${userId}`,
+    order: 'started_at.desc',
+    limit: String(options.limit),
+  };
+
+  if (options.from && options.to) {
+    searchParams.and = `(started_at.gte.${options.from},started_at.lte.${options.to})`;
+  } else if (options.from) {
+    searchParams.started_at = `gte.${options.from}`;
+  } else if (options.to) {
+    searchParams.started_at = `lte.${options.to}`;
+  }
+
+  const query = options.query ? sanitizePostgrestSearchTerm(options.query) : '';
+  if (query) {
+    searchParams.or = `(title.ilike.*${query}*,project.ilike.*${query}*,notes.ilike.*${query}*)`;
+  }
+
+  const project = options.project ? sanitizePostgrestSearchTerm(options.project) : '';
+  if (project) {
+    searchParams.project = `eq.${project}`;
+  }
+
+  const tagsFilter = options.tags ? tagsContainFilter(options.tags) : undefined;
+  if (tagsFilter) {
+    searchParams.tags = tagsFilter;
+  }
+
+  const rows = await request<SessionRow[]>(env, 'GET', 'time_tracker_sessions', {
+    searchParams,
+  });
+
+  return rows.map(mapSessionRow);
 };
 
 export const upsertRunningState = async (
@@ -197,7 +260,7 @@ export const insertSession = async (
       updated_at: new Date().toISOString(),
     },
     searchParams: {
-      select: 'id,title,started_at,ended_at,duration_seconds,tags,project,notes',
+      select: SESSION_SELECT,
     },
     prefer: 'return=representation',
   });

--- a/api/src/security/__tests__/mcpToken.test.ts
+++ b/api/src/security/__tests__/mcpToken.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { generateMcpToken, hashMcpToken, MCP_TOKEN_PREFIX } from '../mcpToken';
+
+describe('mcpToken security helpers', () => {
+  it('generates prefixed high-entropy bearer tokens', () => {
+    const token = generateMcpToken();
+
+    expect(token).toMatch(new RegExp(`^${MCP_TOKEN_PREFIX}[0-9a-f]{64}$`));
+    expect(generateMcpToken()).not.toBe(token);
+  });
+
+  it('hashes tokens with a configured pepper', async () => {
+    const token = `${MCP_TOKEN_PREFIX}${'a'.repeat(64)}`;
+
+    const hash = await hashMcpToken(token, 'pepper');
+
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).not.toContain(token);
+    await expect(hashMcpToken(token, 'other-pepper')).resolves.not.toBe(hash);
+  });
+
+  it('rejects missing pepper and non-MCP token prefixes', async () => {
+    await expect(hashMcpToken(`${MCP_TOKEN_PREFIX}${'a'.repeat(64)}`, undefined)).rejects.toThrow(
+      'MCP_TOKEN_HASH_PEPPER is required',
+    );
+    await expect(hashMcpToken('supabase-jwt', 'pepper')).rejects.toThrow(
+      'Invalid MCP token prefix',
+    );
+  });
+});

--- a/api/src/security/mcpToken.ts
+++ b/api/src/security/mcpToken.ts
@@ -1,0 +1,46 @@
+export const MCP_TOKEN_PREFIX = 'forge_mcp_';
+const MCP_TOKEN_BYTES = 32;
+
+export class McpTokenCryptoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'McpTokenCryptoError';
+  }
+}
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+
+const textBytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+const digestToHex = (digest: ArrayBuffer): string => bytesToHex(new Uint8Array(digest));
+
+const requirePepper = (pepper: string | undefined): string => {
+  const value = pepper?.trim();
+  if (!value) {
+    throw new McpTokenCryptoError('MCP_TOKEN_HASH_PEPPER is required');
+  }
+  return value;
+};
+
+export const generateMcpToken = (): string => {
+  const bytes = new Uint8Array(MCP_TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  return `${MCP_TOKEN_PREFIX}${bytesToHex(bytes)}`;
+};
+
+export const hashMcpToken = async (token: string, pepper: string | undefined): Promise<string> => {
+  if (!token.startsWith(MCP_TOKEN_PREFIX)) {
+    throw new McpTokenCryptoError('Invalid MCP token prefix');
+  }
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    textBytes(requirePepper(pepper)),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, textBytes(token));
+  return digestToHex(signature);
+};

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -92,6 +92,34 @@ export type RunningSessionStatePayload =
 export type RunningSessionStopRequest = {
   id?: string;
   stoppedAt?: string | number;
+  title?: string;
+  project?: string | null;
+  notes?: string | null;
+  tags?: string[];
+  skill?: string | null;
+  intensity?: string | null;
+};
+
+export type TimeTrackerSessionListRequest = {
+  limit?: number;
+  from?: string | number;
+  to?: string | number;
+  query?: string;
+  project?: string;
+  tags?: string[];
+};
+
+export type TimeTrackerSessionRecordRequest = {
+  id?: string;
+  title: string;
+  startedAt: string | number;
+  endedAt: string | number;
+  project?: string | null;
+  notes?: string | null;
+  tags?: string[];
+  skill?: string | null;
+  intensity?: string | null;
+  dryRun?: boolean;
 };
 
 export type TimeTrackerSessionPayload = {
@@ -105,6 +133,68 @@ export type TimeTrackerSessionPayload = {
   tags?: string[];
   skill?: string | null;
   intensity?: string | null;
+};
+
+// ===== 予実管理（タグ単位・曜日別予算） =====
+export type BudgetPayload = {
+  id: string;
+  tag: string;
+  label?: string | null;
+  /** 長さ7・index 0=日曜の1日あたり予算「分」 */
+  weekdayMinutes: number[];
+  effectiveFrom: string; // 'YYYY-MM-DD'
+  effectiveTo?: string | null;
+};
+
+export type BudgetUpsertRequest = {
+  id?: string;
+  tag: string;
+  label?: string | null;
+  weekdayMinutes: number[];
+  effectiveFrom: string;
+  effectiveTo?: string | null;
+};
+
+// ===== デイリーカスタム記録 =====
+export type MetricKind = 'boolean' | 'number' | 'text' | 'single_select' | 'multi_select';
+
+export type MetricOptionPayload = { value: string; label: string };
+
+export type MetricDefinitionPayload = {
+  id: string;
+  name: string;
+  kind: MetricKind;
+  unit?: string | null;
+  options?: MetricOptionPayload[] | null;
+  targetNumber?: number | null;
+  displayOrder: number;
+  archivedAt?: string | null;
+};
+
+export type MetricDefinitionUpsertRequest = {
+  id?: string;
+  name: string;
+  kind: MetricKind;
+  unit?: string | null;
+  options?: MetricOptionPayload[] | null;
+  targetNumber?: number | null;
+  displayOrder?: number;
+};
+
+export type MetricValuePayload = boolean | number | string | string[];
+
+export type MetricEntryPayload = {
+  id: string;
+  metricId: string;
+  entryDate: string; // 'YYYY-MM-DD'
+  value: MetricValuePayload;
+};
+
+export type MetricEntryUpsertRequest = {
+  metricId?: string;
+  metricName?: string;
+  entryDate: string;
+  value: MetricValuePayload;
 };
 
 export type ColumnMappingConfig = {

--- a/app/cloudflare/worker/index.ts
+++ b/app/cloudflare/worker/index.ts
@@ -1,4 +1,4 @@
-const SPA_FALLBACK_PATH = '/index.html';
+const SPA_FALLBACK_PATH = '/';
 
 interface Env {
   ASSETS: AssetsFetcher;
@@ -11,24 +11,37 @@ interface AssetsFetcher {
 const worker: ExportedHandler<Env> = {
   async fetch(request, env) {
     const url = new URL(request.url);
+
+    if (shouldServeSpaDocument(request, url)) {
+      return serveSpaFallback(request, env, url);
+    }
+
     const assetResponse = await env.ASSETS.fetch(request);
 
     if (shouldServeSpaFallback(request, url, assetResponse.status)) {
-      const fallbackUrl = new URL(SPA_FALLBACK_PATH, url.origin);
-      const fallbackRequest = new Request(fallbackUrl.toString(), request);
-      return env.ASSETS.fetch(fallbackRequest);
+      return serveSpaFallback(request, env, url);
     }
 
     return assetResponse;
   },
 };
 
+function serveSpaFallback(request: Request, env: Env, url: URL): Promise<Response> {
+  const fallbackUrl = new URL(SPA_FALLBACK_PATH, url.origin);
+  const fallbackRequest = new Request(fallbackUrl.toString(), request);
+  return env.ASSETS.fetch(fallbackRequest);
+}
+
 function shouldServeSpaFallback(request: Request, url: URL, status: number): boolean {
-  if (request.method !== 'GET') {
+  if (status !== 404) {
     return false;
   }
 
-  if (status !== 404) {
+  return shouldServeSpaDocument(request, url);
+}
+
+function shouldServeSpaDocument(request: Request, url: URL): boolean {
+  if (request.method !== 'GET') {
     return false;
   }
 

--- a/app/package.json
+++ b/app/package.json
@@ -48,6 +48,7 @@
     "prettier": "^3.3.2",
     "typescript": "5.5.4",
     "vite": "^5.2.0",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "wrangler": "^4.42.2"
   }
 }

--- a/app/src/features/daily-log/components/DailyMetricTable/DailyMetricTable.tsx
+++ b/app/src/features/daily-log/components/DailyMetricTable/DailyMetricTable.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import type { MetricDefinition, MetricEntry, MetricValue } from '../../domain/types.ts';
+
+type DailyMetricTableProps = {
+  definitions: MetricDefinition[];
+  days: string[]; // 表示する日付キー（新しい順）
+  todayKey: string;
+  entryFor: (metricId: string, dateKey: string) => MetricEntry | undefined;
+  onCommit: (metricId: string, dateKey: string, value: MetricValue | null) => void;
+  onEditDefinition: (definition: MetricDefinition) => void;
+};
+
+const formatDayLabel = (dateKey: string): string => {
+  const [, month, day] = dateKey.split('-');
+  const weekday = ['日', '月', '火', '水', '木', '金', '土'][
+    new Date(`${dateKey}T00:00:00`).getDay()
+  ];
+  return `${Number(month)}/${Number(day)}(${weekday})`;
+};
+
+/** 数値・テキストの入力セル（編集中はローカル下書き、確定は blur / Enter）。 */
+function EditableCell({
+  kind,
+  value,
+  onCommit,
+}: {
+  kind: 'number' | 'text';
+  value: MetricValue | undefined;
+  onCommit: (value: MetricValue | null) => void;
+}): JSX.Element {
+  const initial = value == null ? '' : String(value);
+  const [draft, setDraft] = useState(initial);
+
+  useEffect(() => {
+    setDraft(value == null ? '' : String(value));
+  }, [value]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === '') {
+      onCommit(null);
+      return;
+    }
+    if (kind === 'number') {
+      const parsed = Number.parseFloat(trimmed);
+      onCommit(Number.isFinite(parsed) ? parsed : null);
+      return;
+    }
+    onCommit(trimmed);
+  };
+
+  return (
+    <input
+      className={`daily-log__cell-input ${kind === 'number' ? 'daily-log__cell-input--number' : ''}`}
+      type={kind === 'number' ? 'number' : 'text'}
+      inputMode={kind === 'number' ? 'decimal' : undefined}
+      step={kind === 'number' ? 'any' : undefined}
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          event.currentTarget.blur();
+        }
+      }}
+      placeholder="—"
+    />
+  );
+}
+
+export function DailyMetricTable({
+  definitions,
+  days,
+  todayKey,
+  entryFor,
+  onCommit,
+  onEditDefinition,
+}: DailyMetricTableProps): JSX.Element {
+  return (
+    <div className="daily-log__table-wrap">
+      <table className="daily-log__table">
+        <thead>
+          <tr>
+            <th className="daily-log__th-date">日付</th>
+            {definitions.map((definition) => (
+              <th key={definition.id}>
+                <button
+                  type="button"
+                  className="daily-log__col-head"
+                  onClick={() => onEditDefinition(definition)}
+                  title="項目を編集"
+                >
+                  {definition.name}
+                  {definition.unit ? (
+                    <span className="daily-log__col-unit">（{definition.unit}）</span>
+                  ) : null}
+                </button>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {days.map((dateKey) => (
+            <tr key={dateKey} className={dateKey === todayKey ? 'daily-log__row--today' : ''}>
+              <th className="daily-log__td-date" scope="row">
+                {formatDayLabel(dateKey)}
+              </th>
+              {definitions.map((definition) => {
+                const entry = entryFor(definition.id, dateKey);
+                const value = entry?.value;
+                return (
+                  <td key={definition.id} className="daily-log__cell">
+                    {definition.kind === 'boolean' ? (
+                      <input
+                        type="checkbox"
+                        className="daily-log__cell-check"
+                        checked={value === true}
+                        onChange={(event) =>
+                          onCommit(definition.id, dateKey, event.target.checked ? true : null)
+                        }
+                        aria-label={`${definition.name} ${formatDayLabel(dateKey)}`}
+                      />
+                    ) : definition.kind === 'single_select' ? (
+                      <select
+                        className="daily-log__cell-select"
+                        value={typeof value === 'string' ? value : ''}
+                        onChange={(event) =>
+                          onCommit(definition.id, dateKey, event.target.value || null)
+                        }
+                        aria-label={`${definition.name} ${formatDayLabel(dateKey)}`}
+                      >
+                        <option value="">—</option>
+                        {(definition.options ?? []).map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    ) : definition.kind === 'number' || definition.kind === 'text' ? (
+                      <EditableCell
+                        kind={definition.kind}
+                        value={value}
+                        onCommit={(next) => onCommit(definition.id, dateKey, next)}
+                      />
+                    ) : (
+                      <span className="daily-log__unsupported">準備中</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/features/daily-log/components/DailyMetricTable/index.ts
+++ b/app/src/features/daily-log/components/DailyMetricTable/index.ts
@@ -1,0 +1,1 @@
+export { DailyMetricTable } from './DailyMetricTable.tsx';

--- a/app/src/features/daily-log/components/MetricDefinitionEditor/MetricDefinitionEditor.tsx
+++ b/app/src/features/daily-log/components/MetricDefinitionEditor/MetricDefinitionEditor.tsx
@@ -1,0 +1,154 @@
+import { type FormEvent, useState } from 'react';
+import type {
+  MetricDefinition,
+  MetricDefinitionInput,
+  MetricKind,
+  MetricOption,
+} from '../../domain/types.ts';
+
+type MetricDefinitionEditorProps = {
+  initial?: MetricDefinition | null;
+  nextDisplayOrder: number;
+  onSave: (input: MetricDefinitionInput) => void;
+  onDelete?: (id: string) => void;
+  onCancel: () => void;
+};
+
+const KIND_OPTIONS: { kind: MetricKind; label: string }[] = [
+  { kind: 'boolean', label: 'チェックボックス' },
+  { kind: 'number', label: '数値' },
+  { kind: 'text', label: 'テキスト' },
+  { kind: 'single_select', label: '選択ボックス' },
+];
+
+const parseOptionsText = (text: string): MetricOption[] =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((value) => ({ value, label: value }));
+
+const optionsToText = (options?: MetricOption[] | null): string =>
+  (options ?? []).map((option) => option.label).join('\n');
+
+export function MetricDefinitionEditor({
+  initial,
+  nextDisplayOrder,
+  onSave,
+  onDelete,
+  onCancel,
+}: MetricDefinitionEditorProps): JSX.Element {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [kind, setKind] = useState<MetricKind>(initial?.kind ?? 'boolean');
+  const [unit, setUnit] = useState(initial?.unit ?? '');
+  const [optionsText, setOptionsText] = useState(optionsToText(initial?.options));
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSave({
+      id: initial?.id,
+      name: trimmed,
+      kind,
+      unit: kind === 'number' && unit.trim() ? unit.trim() : null,
+      options: kind === 'single_select' ? parseOptionsText(optionsText) : null,
+      targetNumber: initial?.targetNumber ?? null,
+      displayOrder: initial?.displayOrder ?? nextDisplayOrder,
+      archivedAt: null,
+    });
+  };
+
+  return (
+    <form className="daily-log__editor" onSubmit={handleSubmit}>
+      <h2 className="daily-log__editor-title">{initial ? '記録項目を編集' : '記録項目を追加'}</h2>
+
+      <label className="daily-log__field">
+        <span className="daily-log__field-label">項目名</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="例: ジムで運動する / 体重 / ひとこと"
+          required
+        />
+      </label>
+
+      <label className="daily-log__field">
+        <span className="daily-log__field-label">入力の種類</span>
+        <select value={kind} onChange={(event) => setKind(event.target.value as MetricKind)}>
+          {KIND_OPTIONS.map((option) => (
+            <option key={option.kind} value={option.kind}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {kind === 'number' ? (
+        <label className="daily-log__field">
+          <span className="daily-log__field-label">単位（任意）</span>
+          <input
+            type="text"
+            value={unit}
+            onChange={(event) => setUnit(event.target.value)}
+            placeholder="例: kg"
+          />
+        </label>
+      ) : null}
+
+      {kind === 'single_select' ? (
+        <label className="daily-log__field">
+          <span className="daily-log__field-label">選択肢（1行に1つ）</span>
+          <textarea
+            className="daily-log__textarea"
+            value={optionsText}
+            onChange={(event) => setOptionsText(event.target.value)}
+            rows={4}
+            placeholder={'良い\n普通\n悪い'}
+          />
+        </label>
+      ) : null}
+
+      <div className="daily-log__editor-actions">
+        {initial && onDelete ? (
+          confirmingDelete ? (
+            <span className="daily-log__confirm">
+              削除しますか？
+              <button
+                type="button"
+                className="daily-log__button-danger"
+                onClick={() => onDelete(initial.id)}
+              >
+                削除する
+              </button>
+              <button
+                type="button"
+                className="daily-log__button-ghost"
+                onClick={() => setConfirmingDelete(false)}
+              >
+                やめる
+              </button>
+            </span>
+          ) : (
+            <button
+              type="button"
+              className="daily-log__button-ghost daily-log__delete-link"
+              onClick={() => setConfirmingDelete(true)}
+            >
+              削除
+            </button>
+          )
+        ) : null}
+        <span className="daily-log__editor-spacer" />
+        <button type="button" className="daily-log__button-ghost" onClick={onCancel}>
+          キャンセル
+        </button>
+        <button type="submit" className="daily-log__button-primary">
+          保存
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/src/features/daily-log/components/MetricDefinitionEditor/index.ts
+++ b/app/src/features/daily-log/components/MetricDefinitionEditor/index.ts
@@ -1,0 +1,1 @@
+export { MetricDefinitionEditor } from './MetricDefinitionEditor.tsx';

--- a/app/src/features/daily-log/daily-log.css
+++ b/app/src/features/daily-log/daily-log.css
@@ -1,0 +1,387 @@
+.daily-log {
+  padding: 1.5rem;
+  color: #0f172a;
+}
+
+.daily-log__panel {
+  max-width: 760px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.daily-log__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.daily-log__header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.daily-log__date-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.daily-log__date {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.daily-log__field-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.daily-log__date input,
+.daily-log__field input,
+.daily-log__field select {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.55rem;
+  font-size: 0.9rem;
+  color: #111827;
+  background: #f9fafc;
+}
+
+.daily-log__date input:focus,
+.daily-log__field input:focus,
+.daily-log__field select:focus {
+  outline: none;
+  border-color: #2563eb;
+  background: #ffffff;
+}
+
+.daily-log__empty {
+  margin: 0;
+  padding: 1.5rem;
+  background: #ffffff;
+  border-radius: 0.85rem;
+  color: #64748b;
+  line-height: 1.7;
+}
+
+.daily-log__card {
+  background: #ffffff;
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.daily-log__controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.daily-log__segmented {
+  display: inline-flex;
+  padding: 0.2rem;
+  background: #eef1f6;
+  border-radius: 0.65rem;
+  gap: 0.2rem;
+}
+
+.daily-log__segmented-item {
+  padding: 0.35rem 0.85rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: #475569;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.daily-log__segmented-item--active {
+  background: #ffffff;
+  color: #1d4ed8;
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+/* 記録テーブル（閲覧＋入力） */
+.daily-log__table-wrap {
+  overflow-x: auto;
+}
+
+.daily-log__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.daily-log__table th,
+.daily-log__table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid #eef1f6;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.daily-log__th-date,
+.daily-log__td-date {
+  text-align: left;
+  position: sticky;
+  left: 0;
+  background: #ffffff;
+  color: #475569;
+  font-weight: 600;
+  /* 右スクロール時に他列が固定列の下を流れるよう前面に出す */
+  z-index: 1;
+  border-right: 1px solid #e2e8f0;
+}
+
+.daily-log__th-date {
+  /* ヘッダーの固定セルは本文の固定セルより前面 */
+  z-index: 2;
+}
+
+.daily-log__table thead th {
+  border-bottom: 1px solid #e2e8f0;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.daily-log__row--today .daily-log__td-date {
+  /* 半透明だと裏の列が透けるので不透明色で固定 */
+  color: #1d4ed8;
+  background: #eaf1ff;
+}
+
+.daily-log__row--today td,
+.daily-log__row--today th {
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.daily-log__col-head {
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: #1f2937;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.daily-log__col-head:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.daily-log__col-unit {
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.daily-log__cell-check {
+  width: 18px;
+  height: 18px;
+  accent-color: #2563eb;
+  cursor: pointer;
+}
+
+.daily-log__cell-input {
+  width: 84px;
+  padding: 0.3rem 0.4rem;
+  border: 1px solid transparent;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+  background: transparent;
+  color: #111827;
+  text-align: center;
+}
+
+.daily-log__cell-input--number {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.daily-log__cell-input:hover {
+  border-color: #e2e8f0;
+}
+
+.daily-log__cell-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  background: #f9fafc;
+}
+
+.daily-log__cell-select {
+  padding: 0.3rem 0.4rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+  background: #ffffff;
+  color: #111827;
+  cursor: pointer;
+}
+
+.daily-log__unsupported {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.daily-log__textarea {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.55rem;
+  font-size: 0.9rem;
+  color: #111827;
+  background: #f9fafc;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.daily-log__textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  background: #ffffff;
+}
+
+.daily-log__confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.daily-log__delete-link {
+  color: #b91c1c;
+}
+
+.daily-log__editor-spacer {
+  flex: 1;
+}
+
+.daily-log__button-danger {
+  padding: 0.45rem 0.85rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.daily-log__trend-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.daily-log__trend-unit {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.daily-log__button-primary {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.daily-log__button-primary:hover {
+  background: #1d4ed8;
+}
+
+.daily-log__button-ghost {
+  padding: 0.45rem 0.85rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.6rem;
+  background: #ffffff;
+  color: #475569;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.daily-log__button-ghost:hover {
+  background: #f1f5f9;
+}
+
+.daily-log__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 10;
+}
+
+.daily-log__overlay-card {
+  background: #ffffff;
+  border-radius: 0.95rem;
+  width: min(460px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.3);
+}
+
+.daily-log__editor {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.daily-log__editor-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.daily-log__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.daily-log__editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+@media (max-width: 640px) {
+  .daily-log {
+    padding: 1rem 0.85rem;
+  }
+
+  .daily-log__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .daily-log__header h1 {
+    font-size: 1.3rem;
+  }
+
+  .daily-log__card {
+    padding: 0.9rem 0.75rem;
+  }
+
+  .daily-log__cell-input {
+    width: 64px;
+  }
+}

--- a/app/src/features/daily-log/domain/metricValue.test.ts
+++ b/app/src/features/daily-log/domain/metricValue.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { formatMetricValue, isValidMetricValue, normalizeMetricValue } from './metricValue.ts';
+
+describe('isValidMetricValue', () => {
+  it('boolean を判定する', () => {
+    expect(isValidMetricValue('boolean', true)).toBe(true);
+    expect(isValidMetricValue('boolean', 1)).toBe(false);
+  });
+
+  it('number は有限数のみ許可', () => {
+    expect(isValidMetricValue('number', 62.5)).toBe(true);
+    expect(isValidMetricValue('number', Number.NaN)).toBe(false);
+    expect(isValidMetricValue('number', '62')).toBe(false);
+  });
+
+  it('text / 選択式を判定できる', () => {
+    expect(isValidMetricValue('text', 'メモ')).toBe(true);
+    expect(isValidMetricValue('single_select', 'a')).toBe(true);
+    expect(isValidMetricValue('multi_select', ['a', 'b'])).toBe(true);
+    expect(isValidMetricValue('multi_select', [1])).toBe(false);
+  });
+});
+
+describe('normalizeMetricValue', () => {
+  it('不正値は null を返す', () => {
+    expect(normalizeMetricValue('number', 'x')).toBeNull();
+    expect(normalizeMetricValue('boolean', false)).toBe(false);
+  });
+});
+
+describe('formatMetricValue', () => {
+  it('boolean は ✓ / —', () => {
+    expect(formatMetricValue('boolean', true)).toBe('✓');
+    expect(formatMetricValue('boolean', false)).toBe('—');
+  });
+
+  it('text はそのまま', () => {
+    expect(formatMetricValue('text', 'ジム行った')).toBe('ジム行った');
+  });
+
+  it('number は単位付き', () => {
+    expect(formatMetricValue('number', 62.5, 'kg')).toBe('62.5 kg');
+  });
+
+  it('未記録は —', () => {
+    expect(formatMetricValue('number', null)).toBe('—');
+  });
+});

--- a/app/src/features/daily-log/domain/metricValue.ts
+++ b/app/src/features/daily-log/domain/metricValue.ts
@@ -1,0 +1,51 @@
+import type { MetricKind, MetricValue } from './types.ts';
+
+/**
+ * kind に対して value が妥当か判定する。
+ * boolean / number は実装済み、選択式は土台（型は通すが UI は将来）。
+ */
+export const isValidMetricValue = (kind: MetricKind, value: unknown): value is MetricValue => {
+  switch (kind) {
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'text':
+    case 'single_select':
+      return typeof value === 'string';
+    case 'multi_select':
+      return Array.isArray(value) && value.every((item) => typeof item === 'string');
+    default:
+      return false;
+  }
+};
+
+/** 永続化された jsonb 値を kind に沿って正規化する。不正なら null。 */
+export const normalizeMetricValue = (kind: MetricKind, value: unknown): MetricValue | null => {
+  if (isValidMetricValue(kind, value)) {
+    return value;
+  }
+  return null;
+};
+
+/** 表示用の文字列化（boolean は ○/×、number は単位付き）。 */
+export const formatMetricValue = (
+  kind: MetricKind,
+  value: MetricValue | null,
+  unit?: string | null,
+): string => {
+  if (value == null) return '—';
+  switch (kind) {
+    case 'boolean':
+      return value ? '✓' : '—';
+    case 'number':
+      return unit ? `${value} ${unit}` : String(value);
+    case 'text':
+    case 'single_select':
+      return String(value);
+    case 'multi_select':
+      return Array.isArray(value) ? value.join(', ') : '';
+    default:
+      return '';
+  }
+};

--- a/app/src/features/daily-log/domain/types.ts
+++ b/app/src/features/daily-log/domain/types.ts
@@ -1,0 +1,50 @@
+// デイリーカスタム記録ドメインの型定義（副作用なし）
+
+/**
+ * 記録項目の種別。
+ * - boolean: チェックボックス（チェック=記録あり）
+ * - number: 数値入力
+ * - text: テキスト入力（自由記述）
+ * - single_select: 選択ボックス（単一）
+ * - multi_select: 複数選択（スキーマ・型の土台。UI は将来）
+ */
+export type MetricKind = 'boolean' | 'number' | 'text' | 'single_select' | 'multi_select';
+
+/** 選択式の選択肢（将来用） */
+export type MetricOption = {
+  value: string;
+  label: string;
+};
+
+/** 記録項目の定義 */
+export type MetricDefinition = {
+  id: string;
+  name: string;
+  kind: MetricKind;
+  unit?: string | null; // 例: 'kg'
+  options?: MetricOption[] | null; // 選択式用（将来）
+  targetNumber?: number | null; // 数値項目の目標値（将来の予実化フック）
+  displayOrder: number;
+  archivedAt?: string | null;
+};
+
+export type MetricDefinitionInput = Omit<MetricDefinition, 'id'> & { id?: string };
+
+/**
+ * 記録値。kind に応じて型が変わる：
+ * - boolean: true/false
+ * - number: 数値
+ * - single_select: 選択肢の value（string）
+ * - multi_select: value の配列（string[]）
+ */
+export type MetricValue = boolean | number | string | string[];
+
+/** ある日のある項目の記録 */
+export type MetricEntry = {
+  id: string;
+  metricId: string;
+  entryDate: string; // 'YYYY-MM-DD'
+  value: MetricValue;
+};
+
+export type MetricEntryInput = Omit<MetricEntry, 'id'> & { id?: string };

--- a/app/src/features/daily-log/hooks/data/useMetricDefinitions.ts
+++ b/app/src/features/daily-log/hooks/data/useMetricDefinitions.ts
@@ -1,0 +1,58 @@
+import { createDailyMetricsDataSource } from '@infra/repository/DailyMetrics';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import type { MetricDefinition, MetricDefinitionInput } from '../../domain/types.ts';
+
+export const METRIC_DEFINITIONS_QUERY_KEY = ['daily-metrics', 'definitions'] as const;
+
+type UseMetricDefinitionsOptions = {
+  userId?: string | null;
+};
+
+export const useMetricDefinitions = (options: UseMetricDefinitionsOptions = {}) => {
+  const { userId = null } = options;
+  const queryClient = useQueryClient();
+
+  const dataSource = useMemo(() => createDailyMetricsDataSource({ userId }), [userId]);
+
+  const definitionsQuery = useQuery({
+    queryKey: METRIC_DEFINITIONS_QUERY_KEY,
+    queryFn: dataSource.listDefinitions,
+    enabled: dataSource.mode !== 'supabase' || Boolean(userId),
+    staleTime: Infinity,
+  });
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: METRIC_DEFINITIONS_QUERY_KEY }),
+    [queryClient],
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: (input: MetricDefinitionInput) => dataSource.saveDefinition(input),
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => dataSource.deleteDefinition(id),
+    onSuccess: invalidate,
+  });
+
+  const saveDefinition = useCallback(
+    (input: MetricDefinitionInput) => saveMutation.mutateAsync(input),
+    [saveMutation],
+  );
+  const deleteDefinition = useCallback(
+    (id: string) => deleteMutation.mutateAsync(id),
+    [deleteMutation],
+  );
+
+  const definitions: MetricDefinition[] = definitionsQuery.data ?? [];
+
+  return {
+    mode: dataSource.mode,
+    definitions,
+    isLoading: definitionsQuery.isLoading,
+    saveDefinition,
+    deleteDefinition,
+  };
+};

--- a/app/src/features/daily-log/hooks/data/useMetricEntries.ts
+++ b/app/src/features/daily-log/hooks/data/useMetricEntries.ts
@@ -1,0 +1,62 @@
+import { createDailyMetricsDataSource } from '@infra/repository/DailyMetrics';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import type { MetricEntry, MetricEntryInput } from '../../domain/types.ts';
+
+type UseMetricEntriesOptions = {
+  userId?: string | null;
+  fromKey: string;
+  toKey: string;
+};
+
+export const metricEntriesQueryKey = (fromKey: string, toKey: string) =>
+  ['daily-metrics', 'entries', fromKey, toKey] as const;
+
+export const useMetricEntries = (options: UseMetricEntriesOptions) => {
+  const { userId = null, fromKey, toKey } = options;
+  const queryClient = useQueryClient();
+
+  const dataSource = useMemo(() => createDailyMetricsDataSource({ userId }), [userId]);
+
+  const entriesQuery = useQuery({
+    queryKey: metricEntriesQueryKey(fromKey, toKey),
+    queryFn: () => dataSource.listEntries(fromKey, toKey),
+    enabled: dataSource.mode !== 'supabase' || Boolean(userId),
+    staleTime: Infinity,
+  });
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: ['daily-metrics', 'entries'] }),
+    [queryClient],
+  );
+
+  const upsertMutation = useMutation({
+    mutationFn: (input: MetricEntryInput) => dataSource.upsertEntry(input),
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (vars: { metricId: string; entryDate: string }) =>
+      dataSource.deleteEntry(vars.metricId, vars.entryDate),
+    onSuccess: invalidate,
+  });
+
+  const upsertEntry = useCallback(
+    (input: MetricEntryInput) => upsertMutation.mutateAsync(input),
+    [upsertMutation],
+  );
+  const deleteEntry = useCallback(
+    (metricId: string, entryDate: string) => deleteMutation.mutateAsync({ metricId, entryDate }),
+    [deleteMutation],
+  );
+
+  const entries: MetricEntry[] = entriesQuery.data ?? [];
+
+  return {
+    mode: dataSource.mode,
+    entries,
+    isLoading: entriesQuery.isLoading,
+    upsertEntry,
+    deleteEntry,
+  };
+};

--- a/app/src/features/daily-log/index.ts
+++ b/app/src/features/daily-log/index.ts
@@ -1,0 +1,10 @@
+export { formatMetricValue } from './domain/metricValue.ts';
+export type {
+  MetricDefinition,
+  MetricEntry,
+  MetricKind,
+  MetricValue,
+} from './domain/types.ts';
+export { useMetricDefinitions } from './hooks/data/useMetricDefinitions.ts';
+export { useMetricEntries } from './hooks/data/useMetricEntries.ts';
+export { DailyLogPage } from './pages/DailyLogPage.tsx';

--- a/app/src/features/daily-log/pages/DailyLogPage.tsx
+++ b/app/src/features/daily-log/pages/DailyLogPage.tsx
@@ -1,0 +1,179 @@
+import { useAuth } from '@infra/auth';
+import { addDays, eachDayKey, toDateKey } from '@lib/date.ts';
+import { LineChart } from '@ui/components/LineChart';
+import { useMemo, useState } from 'react';
+import '../daily-log.css';
+import { DailyMetricTable } from '../components/DailyMetricTable';
+import { MetricDefinitionEditor } from '../components/MetricDefinitionEditor';
+import type {
+  MetricDefinition,
+  MetricDefinitionInput,
+  MetricEntry,
+  MetricValue,
+} from '../domain/types.ts';
+import { useMetricDefinitions } from '../hooks/data/useMetricDefinitions.ts';
+import { useMetricEntries } from '../hooks/data/useMetricEntries.ts';
+
+const TREND_COLOR = '#2563eb';
+const RANGE_OPTIONS = [
+  { days: 14, label: '2週間' },
+  { days: 30, label: '1か月' },
+  { days: 90, label: '3か月' },
+];
+
+type EditorState = { mode: 'create' } | { mode: 'edit'; definition: MetricDefinition } | null;
+
+export function DailyLogPage(): JSX.Element {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+
+  const today = toDateKey(Date.now());
+  const [rangeDays, setRangeDays] = useState(14);
+  const [editor, setEditor] = useState<EditorState>(null);
+
+  const fromKey = addDays(today, -(rangeDays - 1));
+  const { definitions, saveDefinition, deleteDefinition } = useMetricDefinitions({ userId });
+  const { entries, upsertEntry, deleteEntry } = useMetricEntries({ userId, fromKey, toKey: today });
+
+  // (metricId|date) -> entry の索引
+  const entryIndex = useMemo(() => {
+    const map = new Map<string, MetricEntry>();
+    for (const entry of entries) {
+      map.set(`${entry.metricId}|${entry.entryDate}`, entry);
+    }
+    return map;
+  }, [entries]);
+
+  const days = useMemo(() => eachDayKey(fromKey, today).reverse(), [fromKey, today]);
+  const numberDefinitions = definitions.filter((definition) => definition.kind === 'number');
+
+  const handleCommit = (metricId: string, dateKey: string, value: MetricValue | null) => {
+    if (value === null) {
+      void deleteEntry(metricId, dateKey);
+      return;
+    }
+    void upsertEntry({ metricId, entryDate: dateKey, value });
+  };
+
+  const handleSaveDefinition = async (input: MetricDefinitionInput) => {
+    await saveDefinition(input);
+    setEditor(null);
+  };
+
+  const handleDeleteDefinition = async (id: string) => {
+    await deleteDefinition(id);
+    setEditor(null);
+  };
+
+  const trendDays = useMemo(() => eachDayKey(fromKey, today), [fromKey, today]);
+  const trendLabels = trendDays.map((day) => {
+    const [, month, date] = day.split('-');
+    return `${Number(month)}/${Number(date)}`;
+  });
+  const buildTrendValues = (metricId: string): (number | null)[] => {
+    const byDate = new Map<string, number>();
+    for (const entry of entries) {
+      if (entry.metricId === metricId && typeof entry.value === 'number') {
+        byDate.set(entry.entryDate, entry.value);
+      }
+    }
+    return trendDays.map((day) => byDate.get(day) ?? null);
+  };
+
+  return (
+    <main className="daily-log">
+      <div className="daily-log__panel">
+        <header className="daily-log__header">
+          <h1>デイリー記録</h1>
+          <button
+            type="button"
+            className="daily-log__button-primary"
+            onClick={() => setEditor({ mode: 'create' })}
+          >
+            項目を追加
+          </button>
+        </header>
+
+        {definitions.length === 0 ? (
+          <p className="daily-log__empty">
+            「ジムで運動する」をチェックボックス、「体重」を数値で——のように、毎日記録したい項目を追加できます。
+            追加すると、この下の表に日付ごとのマスができ、そのまま入力できます。
+          </p>
+        ) : (
+          <>
+            <div className="daily-log__controls">
+              <div className="daily-log__segmented" role="tablist" aria-label="表示期間">
+                {RANGE_OPTIONS.map((option) => (
+                  <button
+                    key={option.days}
+                    type="button"
+                    role="tab"
+                    aria-selected={rangeDays === option.days}
+                    className={`daily-log__segmented-item ${rangeDays === option.days ? 'daily-log__segmented-item--active' : ''}`}
+                    onClick={() => setRangeDays(option.days)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <section className="daily-log__card" aria-label="記録テーブル">
+              <DailyMetricTable
+                definitions={definitions}
+                days={days}
+                todayKey={today}
+                entryFor={(metricId, dateKey) => entryIndex.get(`${metricId}|${dateKey}`)}
+                onCommit={handleCommit}
+                onEditDefinition={(definition) => setEditor({ mode: 'edit', definition })}
+              />
+            </section>
+
+            {numberDefinitions.map((definition) => (
+              <section
+                key={definition.id}
+                className="daily-log__card"
+                aria-label={`${definition.name}の推移`}
+              >
+                <h2 className="daily-log__trend-title">
+                  {definition.name}の推移
+                  {definition.unit ? (
+                    <span className="daily-log__trend-unit">（{definition.unit}）</span>
+                  ) : null}
+                </h2>
+                <LineChart
+                  labels={trendLabels}
+                  series={[
+                    {
+                      id: definition.id,
+                      label: definition.name,
+                      color: TREND_COLOR,
+                      values: buildTrendValues(definition.id),
+                    },
+                  ]}
+                  height={220}
+                  formatValue={(value) => `${Math.round(value * 10) / 10}`}
+                  ariaLabel={`${definition.name}の推移`}
+                />
+              </section>
+            ))}
+          </>
+        )}
+      </div>
+
+      {editor ? (
+        <div className="daily-log__overlay" role="dialog" aria-modal="true">
+          <div className="daily-log__overlay-card">
+            <MetricDefinitionEditor
+              initial={editor.mode === 'edit' ? editor.definition : null}
+              nextDisplayOrder={definitions.length}
+              onSave={handleSaveDefinition}
+              onDelete={handleDeleteDefinition}
+              onCancel={() => setEditor(null)}
+            />
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/app/src/features/reports/components/BudgetActualTable/BudgetActualTable.tsx
+++ b/app/src/features/reports/components/BudgetActualTable/BudgetActualTable.tsx
@@ -1,0 +1,55 @@
+import { formatHours, formatHoursSigned } from '../../domain/format.ts';
+import type { BudgetActualRow } from '../../domain/types.ts';
+
+type BudgetActualTableProps = {
+  rows: BudgetActualRow[];
+};
+
+const varianceClass = (minutes: number): string => {
+  if (minutes > 0) return 'reports__cell--ahead';
+  if (minutes < 0) return 'reports__cell--behind';
+  return '';
+};
+
+export function BudgetActualTable({ rows }: BudgetActualTableProps): JSX.Element {
+  return (
+    <div className="reports__table-wrap">
+      <table className="reports__table">
+        <thead>
+          <tr>
+            <th rowSpan={2} className="reports__th-date">
+              期間
+            </th>
+            <th colSpan={3}>期間</th>
+            <th colSpan={3}>累積</th>
+          </tr>
+          <tr>
+            <th>予算</th>
+            <th>実績</th>
+            <th>予実差</th>
+            <th>予算</th>
+            <th>実績</th>
+            <th>予実差</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.date}>
+              <td className="reports__td-date">{row.label}</td>
+              <td>{formatHours(row.budgetMinutes)}</td>
+              <td>{formatHours(row.actualMinutes)}</td>
+              <td className={varianceClass(row.varianceMinutes)}>
+                {formatHoursSigned(row.varianceMinutes)}
+              </td>
+              <td>{formatHours(row.cumulativeBudgetMinutes)}</td>
+              <td>{formatHours(row.cumulativeActualMinutes)}</td>
+              <td className={varianceClass(row.cumulativeVarianceMinutes)}>
+                {formatHoursSigned(row.cumulativeVarianceMinutes)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/features/reports/components/BudgetActualTable/index.ts
+++ b/app/src/features/reports/components/BudgetActualTable/index.ts
@@ -1,0 +1,1 @@
+export { BudgetActualTable } from './BudgetActualTable.tsx';

--- a/app/src/features/reports/components/BudgetEditor/BudgetEditor.tsx
+++ b/app/src/features/reports/components/BudgetEditor/BudgetEditor.tsx
@@ -1,0 +1,126 @@
+import { toDateKey } from '@lib/date.ts';
+import { type FormEvent, useState } from 'react';
+import type { Budget, BudgetInput } from '../../domain/types.ts';
+
+type BudgetEditorProps = {
+  initial?: Budget | null;
+  onSave: (input: BudgetInput) => void;
+  onCancel: () => void;
+};
+
+const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+const minutesToHoursInput = (minutes: number): string =>
+  minutes === 0 ? '' : String(Math.round((minutes / 60) * 100) / 100);
+
+const hoursInputToMinutes = (value: string): number => {
+  const hours = Number.parseFloat(value);
+  if (!Number.isFinite(hours) || hours < 0) return 0;
+  return Math.round(hours * 60);
+};
+
+export function BudgetEditor({ initial, onSave, onCancel }: BudgetEditorProps): JSX.Element {
+  const today = toDateKey(Date.now());
+  const [tag, setTag] = useState(initial?.tag ?? '');
+  const [label, setLabel] = useState(initial?.label ?? '');
+  const [hours, setHours] = useState<string[]>(
+    () => (initial?.weekdayMinutes ?? [0, 0, 0, 0, 0, 0, 0]).map(minutesToHoursInput) as string[],
+  );
+  const [effectiveFrom, setEffectiveFrom] = useState(initial?.effectiveFrom ?? today);
+  const [effectiveTo, setEffectiveTo] = useState(initial?.effectiveTo ?? '');
+
+  const handleHoursChange = (index: number, value: string) => {
+    setHours((prev) => prev.map((item, i) => (i === index ? value : item)));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedTag = tag.trim();
+    if (!trimmedTag || !effectiveFrom) return;
+    onSave({
+      id: initial?.id,
+      tag: trimmedTag,
+      label: label.trim() ? label.trim() : null,
+      weekdayMinutes: hours.map(hoursInputToMinutes),
+      effectiveFrom,
+      effectiveTo: effectiveTo ? effectiveTo : null,
+    });
+  };
+
+  return (
+    <form className="reports__editor" onSubmit={handleSubmit}>
+      <h2 className="reports__editor-title">{initial ? '予算を編集' : '予算を追加'}</h2>
+
+      <label className="reports__field">
+        <span className="reports__field-label">対象プロジェクト</span>
+        <input
+          type="text"
+          value={tag}
+          onChange={(event) => setTag(event.target.value)}
+          placeholder="例: 鍛錬（Time Tracker のプロジェクト名）"
+          required
+        />
+      </label>
+
+      <label className="reports__field">
+        <span className="reports__field-label">表示名（任意）</span>
+        <input
+          type="text"
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+          placeholder="例: 累積鍛錬時間"
+        />
+      </label>
+
+      <fieldset className="reports__weekday">
+        <legend className="reports__field-label">曜日別の1日あたり予算（時間）</legend>
+        <div className="reports__weekday-grid">
+          {WEEKDAY_LABELS.map((weekday, index) => (
+            <label key={weekday} className="reports__weekday-item">
+              <span>{weekday}</span>
+              <input
+                type="number"
+                min={0}
+                step={0.5}
+                inputMode="decimal"
+                value={hours[index]}
+                onChange={(event) => handleHoursChange(index, event.target.value)}
+                placeholder="0"
+                aria-label={`${weekday}曜日の予算（時間）`}
+              />
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className="reports__field-row">
+        <label className="reports__field">
+          <span className="reports__field-label">開始日</span>
+          <input
+            type="date"
+            value={effectiveFrom}
+            onChange={(event) => setEffectiveFrom(event.target.value)}
+            required
+          />
+        </label>
+        <label className="reports__field">
+          <span className="reports__field-label">終了日（任意）</span>
+          <input
+            type="date"
+            value={effectiveTo}
+            onChange={(event) => setEffectiveTo(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div className="reports__editor-actions">
+        <button type="button" className="reports__button-ghost" onClick={onCancel}>
+          キャンセル
+        </button>
+        <button type="submit" className="reports__button-primary">
+          保存
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/src/features/reports/components/BudgetEditor/index.ts
+++ b/app/src/features/reports/components/BudgetEditor/index.ts
@@ -1,0 +1,1 @@
+export { BudgetEditor } from './BudgetEditor.tsx';

--- a/app/src/features/reports/components/MetricSeriesTable/MetricSeriesTable.tsx
+++ b/app/src/features/reports/components/MetricSeriesTable/MetricSeriesTable.tsx
@@ -1,0 +1,34 @@
+import type { MetricSeriesRow } from '../../domain/aggregation.ts';
+
+type MetricSeriesTableProps = {
+  rows: MetricSeriesRow[];
+  valueHeader: string;
+  formatValue: (value: number) => string;
+};
+
+export function MetricSeriesTable({
+  rows,
+  valueHeader,
+  formatValue,
+}: MetricSeriesTableProps): JSX.Element {
+  return (
+    <div className="reports__table-wrap">
+      <table className="reports__table">
+        <thead>
+          <tr>
+            <th className="reports__th-date">期間</th>
+            <th>{valueHeader}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.date}>
+              <td className="reports__td-date">{row.label}</td>
+              <td>{row.value == null ? '—' : formatValue(row.value)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/features/reports/components/MetricSeriesTable/index.ts
+++ b/app/src/features/reports/components/MetricSeriesTable/index.ts
@@ -1,0 +1,1 @@
+export { MetricSeriesTable } from './MetricSeriesTable.tsx';

--- a/app/src/features/reports/components/PeriodToggle/PeriodToggle.tsx
+++ b/app/src/features/reports/components/PeriodToggle/PeriodToggle.tsx
@@ -1,0 +1,34 @@
+import type { PeriodUnit } from '../../domain/types.ts';
+
+type PeriodToggleProps = {
+  value: PeriodUnit;
+  onChange: (unit: PeriodUnit) => void;
+};
+
+const OPTIONS: { unit: PeriodUnit; label: string }[] = [
+  { unit: 'day', label: '日次' },
+  { unit: 'week', label: '週次' },
+  { unit: 'month', label: '月次' },
+];
+
+export function PeriodToggle({ value, onChange }: PeriodToggleProps): JSX.Element {
+  return (
+    <div className="reports__segmented" role="tablist" aria-label="集計単位">
+      {OPTIONS.map((option) => {
+        const isActive = option.unit === value;
+        return (
+          <button
+            key={option.unit}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            className={`reports__segmented-item ${isActive ? 'reports__segmented-item--active' : ''}`}
+            onClick={() => onChange(option.unit)}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/features/reports/components/PeriodToggle/index.ts
+++ b/app/src/features/reports/components/PeriodToggle/index.ts
@@ -1,0 +1,1 @@
+export { PeriodToggle } from './PeriodToggle.tsx';

--- a/app/src/features/reports/domain/aggregation.test.ts
+++ b/app/src/features/reports/domain/aggregation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBudgetActualRows,
+  dailyActualMinutes,
+  dailyBudgetMinutes,
+  type SessionLike,
+} from './aggregation.ts';
+import type { Budget } from './types.ts';
+
+// 月=180分(3h), 土日=0、その他平日=180分。2025-01-06(月)〜
+const budget: Budget = {
+  id: 'b1',
+  tag: '鍛錬',
+  weekdayMinutes: [0, 180, 180, 180, 180, 180, 0], // 日,月,火,水,木,金,土
+  effectiveFrom: '2025-01-06',
+  effectiveTo: null,
+};
+
+const sessionAt = (dateKey: string, minutes: number, tags: string[] = ['鍛錬']): SessionLike => ({
+  startedAt: new Date(`${dateKey}T10:00:00`).getTime(),
+  durationSeconds: minutes * 60,
+  tags,
+});
+
+describe('dailyBudgetMinutes', () => {
+  it('曜日別スケジュールで日次予算を生成する', () => {
+    const map = dailyBudgetMinutes(budget, '2025-01-06', '2025-01-12');
+    expect(map.get('2025-01-06')).toBe(180); // 月
+    expect(map.get('2025-01-11')).toBe(0); // 土
+    expect(map.get('2025-01-12')).toBe(0); // 日
+  });
+
+  it('有効期間外は 0 になる', () => {
+    const map = dailyBudgetMinutes(budget, '2025-01-04', '2025-01-06');
+    expect(map.get('2025-01-04')).toBe(0); // effectiveFrom より前
+    expect(map.get('2025-01-06')).toBe(180);
+  });
+});
+
+describe('dailyActualMinutes', () => {
+  it('対象タグのセッションのみ日次合計する', () => {
+    const sessions = [
+      sessionAt('2025-01-06', 60),
+      sessionAt('2025-01-06', 30),
+      sessionAt('2025-01-07', 120, ['別タグ']),
+    ];
+    const map = dailyActualMinutes(sessions, '鍛錬', '2025-01-06', '2025-01-07');
+    expect(map.get('2025-01-06')).toBe(90);
+    expect(map.get('2025-01-07')).toBe(0);
+  });
+
+  it('project が対象名に一致するセッションも拾う（web UI は project のみ記録）', () => {
+    const sessions: SessionLike[] = [
+      {
+        startedAt: new Date('2025-01-06T10:00:00').getTime(),
+        durationSeconds: 150 * 60,
+        project: '鍛錬',
+      },
+      {
+        startedAt: new Date('2025-01-06T12:00:00').getTime(),
+        durationSeconds: 60 * 60,
+        project: '別',
+      },
+    ];
+    const map = dailyActualMinutes(sessions, '鍛錬', '2025-01-06', '2025-01-06');
+    expect(map.get('2025-01-06')).toBe(150);
+  });
+});
+
+describe('buildBudgetActualRows', () => {
+  it('日次で予実差と累積を計算する', () => {
+    const sessions = [sessionAt('2025-01-06', 200), sessionAt('2025-01-07', 100)];
+    const rows = buildBudgetActualRows(budget, sessions, '2025-01-06', '2025-01-07', 'day');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      budgetMinutes: 180,
+      actualMinutes: 200,
+      varianceMinutes: 20,
+      cumulativeBudgetMinutes: 180,
+      cumulativeActualMinutes: 200,
+    });
+    expect(rows[1]).toMatchObject({
+      budgetMinutes: 180,
+      actualMinutes: 100,
+      varianceMinutes: -80,
+      cumulativeBudgetMinutes: 360,
+      cumulativeActualMinutes: 300,
+      cumulativeVarianceMinutes: -60,
+    });
+  });
+
+  it('週次でバケットを束ねる（月曜開始）', () => {
+    const sessions = [sessionAt('2025-01-06', 60), sessionAt('2025-01-08', 60)];
+    const rows = buildBudgetActualRows(budget, sessions, '2025-01-06', '2025-01-12', 'week');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].date).toBe('2025-01-06');
+    expect(rows[0].budgetMinutes).toBe(180 * 5); // 平日5日分
+    expect(rows[0].actualMinutes).toBe(120);
+  });
+
+  it('月次でバケットを束ねる', () => {
+    const sessions = [sessionAt('2025-01-06', 60), sessionAt('2025-02-03', 90)];
+    const rows = buildBudgetActualRows(budget, sessions, '2025-01-06', '2025-02-03', 'month');
+    expect(rows.map((r) => r.date)).toEqual(['2025-01-01', '2025-02-01']);
+    expect(rows[1].actualMinutes).toBe(90);
+  });
+});

--- a/app/src/features/reports/domain/aggregation.ts
+++ b/app/src/features/reports/domain/aggregation.ts
@@ -1,0 +1,209 @@
+import { eachDayKey, monthStartKey, toDateKey, weekdayIndex, weekStartKey } from '@lib/date.ts';
+import type { Budget, BudgetActualRow, PeriodUnit } from './types.ts';
+
+/**
+ * 集計に必要なセッションの最小形（features 間結合を避けるため構造的に受ける）。
+ * startedAt はミリ秒タイムスタンプ、durationSeconds は秒。
+ * tags / project どちらで分類しても拾えるよう両方を見る。
+ */
+export type SessionLike = {
+  startedAt: number;
+  durationSeconds: number;
+  tags?: string[];
+  project?: string | null;
+};
+
+/** セッションが予算の対象（tag）に該当するか。タグ一致 or プロジェクト一致で拾う。 */
+const matchesTag = (session: SessionLike, tag: string): boolean =>
+  (session.tags?.includes(tag) ?? false) || session.project === tag;
+
+/** デイリー記録の最小形 */
+export type EntryLike = {
+  metricId: string;
+  entryDate: string; // 'YYYY-MM-DD'
+  value: boolean | number | string | string[];
+};
+
+export type Bucket = {
+  key: string; // バケット開始日 'YYYY-MM-DD'
+  label: string;
+  dayKeys: string[];
+};
+
+export type MetricSeriesRow = {
+  date: string;
+  label: string;
+  value: number | null;
+};
+
+const minutesFromSeconds = (seconds: number): number => seconds / 60;
+
+const bucketStartKey = (dayKey: string, unit: PeriodUnit, weekStartsOn: number): string => {
+  if (unit === 'day') return dayKey;
+  if (unit === 'week') return weekStartKey(dayKey, weekStartsOn);
+  return monthStartKey(dayKey);
+};
+
+const formatBucketLabel = (bucketKey: string, unit: PeriodUnit, withYear: boolean): string => {
+  const [year, month, day] = bucketKey.split('-');
+  const m = Number(month);
+  const d = Number(day);
+  if (unit === 'month') return `${year}/${month}`;
+  if (unit === 'week') return withYear ? `${year}/${m}/${d}週` : `${m}/${d}週`;
+  return withYear ? `${year}/${m}/${d}` : `${m}/${d}`;
+};
+
+/** 期間・単位から、順序付きのバケット（各バケットに含まれる日付キー）を作る。 */
+export const buildBuckets = (
+  fromKey: string,
+  toKey: string,
+  unit: PeriodUnit,
+  options: { weekStartsOn?: number; withYear?: boolean } = {},
+): Bucket[] => {
+  const weekStartsOn = options.weekStartsOn ?? 1;
+  const withYear = options.withYear ?? fromKey.slice(0, 4) !== toKey.slice(0, 4);
+  const buckets = new Map<string, Bucket>();
+  const order: string[] = [];
+  for (const dayKey of eachDayKey(fromKey, toKey)) {
+    const key = bucketStartKey(dayKey, unit, weekStartsOn);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { key, label: formatBucketLabel(key, unit, withYear), dayKeys: [] };
+      buckets.set(key, bucket);
+      order.push(key);
+    }
+    bucket.dayKeys.push(dayKey);
+  }
+  return order.map((key) => buckets.get(key) as Bucket);
+};
+
+/** tag を含むセッションを日次でバケットし、各日の実績「分」を返す（範囲内は 0 で初期化）。 */
+export const dailyActualMinutes = (
+  sessions: SessionLike[],
+  tag: string,
+  fromKey: string,
+  toKey: string,
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  for (const key of eachDayKey(fromKey, toKey)) {
+    map.set(key, 0);
+  }
+  for (const session of sessions) {
+    if (!matchesTag(session, tag)) continue;
+    const key = toDateKey(session.startedAt);
+    if (key < fromKey || key > toKey) continue;
+    map.set(key, (map.get(key) ?? 0) + minutesFromSeconds(session.durationSeconds));
+  }
+  return map;
+};
+
+/** 曜日別スケジュールと有効期間から、各日の予算「分」を返す。 */
+export const dailyBudgetMinutes = (
+  budget: Budget,
+  fromKey: string,
+  toKey: string,
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  for (const key of eachDayKey(fromKey, toKey)) {
+    const inRange =
+      key >= budget.effectiveFrom && (budget.effectiveTo == null || key <= budget.effectiveTo);
+    const minutes = inRange ? (budget.weekdayMinutes[weekdayIndex(key)] ?? 0) : 0;
+    map.set(key, minutes);
+  }
+  return map;
+};
+
+/**
+ * 予算とセッションから、指定期間・単位の予実行を生成する。
+ * 期間別の予算/実績/差に加えて累積も持つ。累積は範囲内での積み上げ。
+ */
+export const buildBudgetActualRows = (
+  budget: Budget,
+  sessions: SessionLike[],
+  fromKey: string,
+  toKey: string,
+  unit: PeriodUnit,
+  options: { weekStartsOn?: number; withYear?: boolean } = {},
+): BudgetActualRow[] => {
+  const budgetDaily = dailyBudgetMinutes(budget, fromKey, toKey);
+  const actualDaily = dailyActualMinutes(sessions, budget.tag, fromKey, toKey);
+  const buckets = buildBuckets(fromKey, toKey, unit, options);
+
+  let cumulativeBudget = 0;
+  let cumulativeActual = 0;
+  return buckets.map((bucket) => {
+    let budgetMinutes = 0;
+    let actualMinutes = 0;
+    for (const dayKey of bucket.dayKeys) {
+      budgetMinutes += budgetDaily.get(dayKey) ?? 0;
+      actualMinutes += actualDaily.get(dayKey) ?? 0;
+    }
+    cumulativeBudget += budgetMinutes;
+    cumulativeActual += actualMinutes;
+    return {
+      date: bucket.key,
+      label: bucket.label,
+      budgetMinutes,
+      actualMinutes,
+      varianceMinutes: actualMinutes - budgetMinutes,
+      cumulativeBudgetMinutes: cumulativeBudget,
+      cumulativeActualMinutes: cumulativeActual,
+      cumulativeVarianceMinutes: cumulativeActual - cumulativeBudget,
+    };
+  });
+};
+
+const collectEntryDaily = (
+  entries: EntryLike[],
+  metricId: string,
+  fromKey: string,
+  toKey: string,
+): Map<string, EntryLike> => {
+  const map = new Map<string, EntryLike>();
+  for (const entry of entries) {
+    if (entry.metricId !== metricId) continue;
+    if (entry.entryDate < fromKey || entry.entryDate > toKey) continue;
+    map.set(entry.entryDate, entry);
+  }
+  return map;
+};
+
+/** 数値メトリクスをバケット平均で集計する（記録のない日は除外、なければ null）。 */
+export const buildNumberMetricRows = (
+  entries: EntryLike[],
+  metricId: string,
+  fromKey: string,
+  toKey: string,
+  unit: PeriodUnit,
+  options: { weekStartsOn?: number; withYear?: boolean } = {},
+): MetricSeriesRow[] => {
+  const daily = collectEntryDaily(entries, metricId, fromKey, toKey);
+  return buildBuckets(fromKey, toKey, unit, options).map((bucket) => {
+    const nums: number[] = [];
+    for (const dayKey of bucket.dayKeys) {
+      const entry = daily.get(dayKey);
+      if (entry && typeof entry.value === 'number') nums.push(entry.value);
+    }
+    const value = nums.length > 0 ? nums.reduce((sum, n) => sum + n, 0) / nums.length : null;
+    return { date: bucket.key, label: bucket.label, value };
+  });
+};
+
+/** 真偽メトリクスをバケット内の達成回数（true の日数）で集計する。 */
+export const buildBooleanMetricRows = (
+  entries: EntryLike[],
+  metricId: string,
+  fromKey: string,
+  toKey: string,
+  unit: PeriodUnit,
+  options: { weekStartsOn?: number; withYear?: boolean } = {},
+): MetricSeriesRow[] => {
+  const daily = collectEntryDaily(entries, metricId, fromKey, toKey);
+  return buildBuckets(fromKey, toKey, unit, options).map((bucket) => {
+    let count = 0;
+    for (const dayKey of bucket.dayKeys) {
+      if (daily.get(dayKey)?.value === true) count += 1;
+    }
+    return { date: bucket.key, label: bucket.label, value: count };
+  });
+};

--- a/app/src/features/reports/domain/format.ts
+++ b/app/src/features/reports/domain/format.ts
@@ -1,0 +1,13 @@
+// 予実表示用の整形（分 → 時間）。副作用なし。
+
+export const minutesToHours = (minutes: number): number => minutes / 60;
+
+/** 例: 90 -> "1.5h" */
+export const formatHours = (minutes: number): string => `${(minutes / 60).toFixed(1)}h`;
+
+/** 予実差用。符号付き。例: +138 -> "+2.3h" / -90 -> "-1.5h" */
+export const formatHoursSigned = (minutes: number): string => {
+  const hours = minutes / 60;
+  const sign = hours >= 0 ? '+' : '';
+  return `${sign}${hours.toFixed(1)}h`;
+};

--- a/app/src/features/reports/domain/types.ts
+++ b/app/src/features/reports/domain/types.ts
@@ -1,0 +1,39 @@
+// 予実管理ドメインの型定義（副作用なし）
+
+/** 集計の単位 */
+export type PeriodUnit = 'day' | 'week' | 'month';
+
+/**
+ * タグ単位の予算定義。
+ * weekdayMinutes は長さ7・index 0=日曜（JS Date.getDay() 準拠）の
+ * 1日あたり予算「分」。effectiveTo が null の場合は継続中。
+ */
+export type Budget = {
+  id: string;
+  tag: string;
+  label?: string | null;
+  weekdayMinutes: number[];
+  effectiveFrom: string; // 'YYYY-MM-DD'
+  effectiveTo?: string | null; // 'YYYY-MM-DD' | null
+};
+
+/** 予算の新規作成・更新用入力（id は未確定なら省略） */
+export type BudgetInput = Omit<Budget, 'id'> & { id?: string };
+
+/**
+ * 期間（日次/週次/月次）ごとの予実1行。
+ * スプレッドシートの「期間別 予算/実績/差」＋「累積 予算/実績/差」に対応。
+ * 数値はすべて「分」。表示側で時間に変換する。
+ */
+export type BudgetActualRow = {
+  /** バケット開始日のキー 'YYYY-MM-DD'（チャートの x 軸に使う） */
+  date: string;
+  /** 表示用ラベル（'M/D' / 'M/D週' / 'YYYY/MM'） */
+  label: string;
+  budgetMinutes: number;
+  actualMinutes: number;
+  varianceMinutes: number;
+  cumulativeBudgetMinutes: number;
+  cumulativeActualMinutes: number;
+  cumulativeVarianceMinutes: number;
+};

--- a/app/src/features/reports/hooks/data/useBudgets.ts
+++ b/app/src/features/reports/hooks/data/useBudgets.ts
@@ -1,0 +1,58 @@
+import { createBudgetsDataSource } from '@infra/repository/Budgets';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import type { Budget, BudgetInput } from '../../domain/types.ts';
+
+export const BUDGETS_QUERY_KEY = ['budgets'] as const;
+
+type UseBudgetsOptions = {
+  userId?: string | null;
+};
+
+export const useBudgets = (options: UseBudgetsOptions = {}) => {
+  const { userId = null } = options;
+  const queryClient = useQueryClient();
+
+  const dataSource = useMemo(() => createBudgetsDataSource({ userId }), [userId]);
+
+  const budgetsQuery = useQuery({
+    queryKey: BUDGETS_QUERY_KEY,
+    queryFn: dataSource.listBudgets,
+    enabled: dataSource.mode !== 'supabase' || Boolean(userId),
+    staleTime: Infinity,
+  });
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: BUDGETS_QUERY_KEY }),
+    [queryClient],
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: (input: BudgetInput) => dataSource.saveBudget(input),
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => dataSource.deleteBudget(id),
+    onSuccess: invalidate,
+  });
+
+  const saveBudget = useCallback(
+    (input: BudgetInput) => saveMutation.mutateAsync(input),
+    [saveMutation],
+  );
+  const deleteBudget = useCallback(
+    (id: string) => deleteMutation.mutateAsync(id),
+    [deleteMutation],
+  );
+
+  const budgets: Budget[] = budgetsQuery.data ?? [];
+
+  return {
+    mode: dataSource.mode,
+    budgets,
+    isLoading: budgetsQuery.isLoading,
+    saveBudget,
+    deleteBudget,
+  };
+};

--- a/app/src/features/reports/index.ts
+++ b/app/src/features/reports/index.ts
@@ -1,0 +1,2 @@
+export type { Budget, BudgetActualRow, PeriodUnit } from './domain/types.ts';
+export { ReportsPage } from './pages/ReportsPage.tsx';

--- a/app/src/features/reports/pages/ReportsPage.tsx
+++ b/app/src/features/reports/pages/ReportsPage.tsx
@@ -1,0 +1,355 @@
+import { useMetricDefinitions, useMetricEntries } from '@features/daily-log';
+import { useTimeTrackerSessions } from '@features/time-tracker/hooks/data/useTimeTrackerSessions.ts';
+import { useAuth } from '@infra/auth';
+import { addDays, addMonths, toDateKey } from '@lib/date.ts';
+import { LineChart } from '@ui/components/LineChart';
+import { RangeControl } from '@ui/components/RangeControl';
+import { useMemo, useState } from 'react';
+import '../reports.css';
+import { BudgetActualTable } from '../components/BudgetActualTable';
+import { BudgetEditor } from '../components/BudgetEditor';
+import { MetricSeriesTable } from '../components/MetricSeriesTable';
+import { PeriodToggle } from '../components/PeriodToggle';
+import {
+  buildBooleanMetricRows,
+  buildBudgetActualRows,
+  buildNumberMetricRows,
+  type EntryLike,
+  type SessionLike,
+} from '../domain/aggregation.ts';
+import type { Budget, BudgetInput, PeriodUnit } from '../domain/types.ts';
+import { useBudgets } from '../hooks/data/useBudgets.ts';
+
+const BUDGET_COLOR = '#2563eb';
+const ACTUAL_COLOR = '#ef4444';
+const METRIC_COLOR = '#2563eb';
+
+type EditorState = { mode: 'create' } | { mode: 'edit'; budget: Budget } | null;
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+export function ReportsPage(): JSX.Element {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const today = toDateKey(Date.now());
+
+  const [range, setRange] = useState(() => ({
+    fromKey: addDays(addMonths(today, -3), 1),
+    toKey: today,
+  }));
+  const [period, setPeriod] = useState<PeriodUnit>('week');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [editor, setEditor] = useState<EditorState>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const { sessions } = useTimeTrackerSessions({ userId });
+  const { budgets, saveBudget, deleteBudget } = useBudgets({ userId });
+  const { definitions } = useMetricDefinitions({ userId });
+  const { entries } = useMetricEntries({ userId, fromKey: range.fromKey, toKey: range.toKey });
+
+  // レポートで扱える記録（数値=推移 / 真偽=達成回数）
+  const reportableMetrics = definitions.filter(
+    (definition) => definition.kind === 'number' || definition.kind === 'boolean',
+  );
+
+  type Source =
+    | { type: 'budget'; id: string; label: string; budget: Budget }
+    | { type: 'metric'; id: string; label: string };
+  const sources: Source[] = [
+    ...budgets.map((budget) => ({
+      type: 'budget' as const,
+      id: `budget:${budget.id}`,
+      label: budget.label ?? budget.tag,
+      budget,
+    })),
+    ...reportableMetrics.map((definition) => ({
+      type: 'metric' as const,
+      id: `metric:${definition.id}`,
+      label: definition.name,
+    })),
+  ];
+
+  const selected = sources.find((source) => source.id === selectedId) ?? sources[0] ?? null;
+  const selectedBudget = selected?.type === 'budget' ? selected.budget : null;
+  const selectedMetric =
+    selected?.type === 'metric'
+      ? (reportableMetrics.find((definition) => `metric:${definition.id}` === selected.id) ?? null)
+      : null;
+
+  const budgetRows = useMemo(() => {
+    if (!selectedBudget) return [];
+    return buildBudgetActualRows(
+      selectedBudget,
+      sessions as SessionLike[],
+      range.fromKey,
+      range.toKey,
+      period,
+    );
+  }, [selectedBudget, sessions, range, period]);
+
+  const metricRows = useMemo(() => {
+    if (!selectedMetric) return [];
+    if (selectedMetric.kind === 'number') {
+      return buildNumberMetricRows(
+        entries as EntryLike[],
+        selectedMetric.id,
+        range.fromKey,
+        range.toKey,
+        period,
+      );
+    }
+    return buildBooleanMetricRows(
+      entries as EntryLike[],
+      selectedMetric.id,
+      range.fromKey,
+      range.toKey,
+      period,
+    );
+  }, [selectedMetric, entries, range, period]);
+
+  const handleSave = async (input: BudgetInput) => {
+    const saved = await saveBudget(input);
+    setSelectedId(`budget:${saved.id}`);
+    setEditor(null);
+  };
+
+  const handleDelete = async () => {
+    if (!selectedBudget) return;
+    await deleteBudget(selectedBudget.id);
+    setSelectedId(null);
+    setConfirmingDelete(false);
+  };
+
+  const renderBudget = (budget: Budget) => (
+    <>
+      <section className="reports__chart-card" aria-label="累積の予算と実績">
+        <div className="reports__chart-head">
+          <h2>
+            累積時間の予算と実績
+            <span className="reports__chart-tag">{budget.label ?? budget.tag}</span>
+          </h2>
+          <div className="reports__legend">
+            <span className="reports__legend-item">
+              <span className="reports__legend-dot" style={{ background: BUDGET_COLOR }} />
+              予算
+            </span>
+            <span className="reports__legend-item">
+              <span className="reports__legend-dot" style={{ background: ACTUAL_COLOR }} />
+              実績
+            </span>
+          </div>
+        </div>
+        {budgetRows.length === 0 ? (
+          <p className="reports__empty">この期間に表示できるデータがありません。</p>
+        ) : (
+          <LineChart
+            labels={budgetRows.map((row) => row.label)}
+            series={[
+              {
+                id: 'budget',
+                label: '予算',
+                color: BUDGET_COLOR,
+                values: budgetRows.map((row) => row.cumulativeBudgetMinutes / 60),
+              },
+              {
+                id: 'actual',
+                label: '実績',
+                color: ACTUAL_COLOR,
+                values: budgetRows.map((row) => row.cumulativeActualMinutes / 60),
+              },
+            ]}
+            yBaseline="zero"
+            formatValue={(value) => `${Math.round(value)}h`}
+            ariaLabel="累積時間の予算と実績"
+          />
+        )}
+      </section>
+      <section className="reports__table-card" aria-label="予実テーブル">
+        <BudgetActualTable rows={budgetRows} />
+      </section>
+      <div className="reports__budget-actions">
+        <button
+          type="button"
+          className="reports__button-ghost"
+          onClick={() => setEditor({ mode: 'edit', budget })}
+        >
+          予算を編集
+        </button>
+        {confirmingDelete ? (
+          <span className="reports__confirm">
+            削除しますか？
+            <button type="button" className="reports__button-danger" onClick={handleDelete}>
+              削除する
+            </button>
+            <button
+              type="button"
+              className="reports__button-ghost"
+              onClick={() => setConfirmingDelete(false)}
+            >
+              やめる
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="reports__button-ghost"
+            onClick={() => setConfirmingDelete(true)}
+          >
+            予算を削除
+          </button>
+        )}
+      </div>
+    </>
+  );
+
+  const renderMetric = () => {
+    if (!selectedMetric) return null;
+    const isNumber = selectedMetric.kind === 'number';
+    const unit = selectedMetric.unit ?? '';
+    const valueHeader = isNumber ? (unit ? `平均（${unit}）` : '平均') : '達成回数';
+    return (
+      <>
+        <section className="reports__chart-card" aria-label={`${selectedMetric.name}の推移`}>
+          <div className="reports__chart-head">
+            <h2>
+              {selectedMetric.name}
+              <span className="reports__chart-tag">
+                {isNumber ? '推移' : '達成回数'}
+                {isNumber && unit ? `（${unit}）` : ''}
+              </span>
+            </h2>
+          </div>
+          {metricRows.length === 0 ? (
+            <p className="reports__empty">この期間に表示できるデータがありません。</p>
+          ) : (
+            <LineChart
+              labels={metricRows.map((row) => row.label)}
+              series={[
+                {
+                  id: selectedMetric.id,
+                  label: selectedMetric.name,
+                  color: METRIC_COLOR,
+                  values: metricRows.map((row) => (row.value == null ? null : round1(row.value))),
+                },
+              ]}
+              yBaseline={isNumber ? 'auto' : 'zero'}
+              formatValue={(value) => (isNumber ? String(round1(value)) : `${Math.round(value)}`)}
+              ariaLabel={`${selectedMetric.name}の推移`}
+            />
+          )}
+        </section>
+        <section className="reports__table-card" aria-label={`${selectedMetric.name}のテーブル`}>
+          <MetricSeriesTable
+            rows={metricRows}
+            valueHeader={valueHeader}
+            formatValue={(value) =>
+              isNumber ? `${round1(value)}${unit ? ` ${unit}` : ''}` : `${Math.round(value)}回`
+            }
+          />
+        </section>
+      </>
+    );
+  };
+
+  return (
+    <main className="reports">
+      <div className="reports__panel">
+        <header className="reports__header">
+          <h1>レポート</h1>
+          <button
+            type="button"
+            className="reports__button-primary"
+            onClick={() => setEditor({ mode: 'create' })}
+          >
+            予算を追加
+          </button>
+        </header>
+
+        {sources.length === 0 ? (
+          <p className="reports__empty">
+            プロジェクト単位で予算を設定すると、累積の予算曲線と実績、予実差を確認できます。
+            「予算を追加」から始めましょう。デイリー記録（数値・チェック）も、記録すればここに表示されます。
+          </p>
+        ) : (
+          <>
+            <div className="reports__source-row">
+              {budgets.length > 0 ? (
+                <div className="reports__source-group">
+                  <span className="reports__source-label">予実</span>
+                  <div className="reports__budget-tabs" role="tablist" aria-label="予実">
+                    {sources
+                      .filter((source) => source.type === 'budget')
+                      .map((source) => (
+                        <button
+                          key={source.id}
+                          type="button"
+                          role="tab"
+                          aria-selected={source.id === selected?.id}
+                          className={`reports__budget-tab ${source.id === selected?.id ? 'reports__budget-tab--active' : ''}`}
+                          onClick={() => {
+                            setSelectedId(source.id);
+                            setConfirmingDelete(false);
+                          }}
+                        >
+                          {source.label}
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              ) : null}
+              {reportableMetrics.length > 0 ? (
+                <div className="reports__source-group">
+                  <span className="reports__source-label">記録</span>
+                  <div className="reports__budget-tabs" role="tablist" aria-label="デイリー記録">
+                    {sources
+                      .filter((source) => source.type === 'metric')
+                      .map((source) => (
+                        <button
+                          key={source.id}
+                          type="button"
+                          role="tab"
+                          aria-selected={source.id === selected?.id}
+                          className={`reports__budget-tab ${source.id === selected?.id ? 'reports__budget-tab--active' : ''}`}
+                          onClick={() => {
+                            setSelectedId(source.id);
+                            setConfirmingDelete(false);
+                          }}
+                        >
+                          {source.label}
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="reports__controls">
+              <RangeControl
+                fromKey={range.fromKey}
+                toKey={range.toKey}
+                todayKey={today}
+                onChange={(fromKey, toKey) => setRange({ fromKey, toKey })}
+              />
+              <PeriodToggle value={period} onChange={setPeriod} />
+            </div>
+
+            {selectedBudget ? renderBudget(selectedBudget) : null}
+            {selectedMetric ? renderMetric() : null}
+          </>
+        )}
+      </div>
+
+      {editor ? (
+        <div className="reports__overlay" role="dialog" aria-modal="true">
+          <div className="reports__overlay-card">
+            <BudgetEditor
+              initial={editor.mode === 'edit' ? editor.budget : null}
+              onSave={handleSave}
+              onCancel={() => setEditor(null)}
+            />
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/app/src/features/reports/reports.css
+++ b/app/src/features/reports/reports.css
@@ -1,0 +1,414 @@
+.reports {
+  padding: 1.5rem;
+  color: #0f172a;
+}
+
+.reports__panel {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.reports__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.reports__header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.reports__empty {
+  margin: 0;
+  padding: 1.5rem;
+  background: #ffffff;
+  border-radius: 0.85rem;
+  color: #64748b;
+  line-height: 1.7;
+}
+
+.reports__source-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.reports__source-group {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.reports__source-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
+  min-width: 2.4rem;
+}
+
+.reports__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.reports__budget-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.reports__budget-tab {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 9999px;
+  background: #ffffff;
+  color: #475569;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.reports__budget-tab--active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.reports__segmented {
+  display: inline-flex;
+  padding: 0.2rem;
+  background: #eef1f6;
+  border-radius: 0.65rem;
+  gap: 0.2rem;
+}
+
+.reports__segmented-item {
+  padding: 0.35rem 0.85rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: #475569;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.reports__segmented-item--active {
+  background: #ffffff;
+  color: #1d4ed8;
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.reports__chart-card,
+.reports__table-card {
+  background: #ffffff;
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.reports__chart-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.reports__chart-head h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.reports__chart-tag {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.reports__legend {
+  display: flex;
+  gap: 0.9rem;
+}
+
+.reports__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.reports__legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+}
+
+.reports__table-wrap {
+  overflow-x: auto;
+}
+
+.reports__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.reports__table th,
+.reports__table td {
+  padding: 0.45rem 0.6rem;
+  text-align: right;
+  border-bottom: 1px solid #eef1f6;
+  white-space: nowrap;
+}
+
+.reports__table thead th {
+  color: #64748b;
+  font-weight: 600;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.reports__th-date,
+.reports__td-date {
+  text-align: left;
+}
+
+.reports__cell--ahead {
+  background: rgba(34, 197, 94, 0.14);
+  color: #15803d;
+}
+
+.reports__cell--behind {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.reports__budget-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.reports__confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.reports__button-primary {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.reports__button-primary:hover {
+  background: #1d4ed8;
+}
+
+.reports__button-ghost {
+  padding: 0.45rem 0.85rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.6rem;
+  background: #ffffff;
+  color: #475569;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.reports__button-ghost:hover {
+  background: #f1f5f9;
+}
+
+.reports__button-danger {
+  padding: 0.45rem 0.85rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* エディタ */
+.reports__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 10;
+}
+
+.reports__overlay-card {
+  background: #ffffff;
+  border-radius: 0.95rem;
+  width: min(520px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.3);
+}
+
+.reports__editor {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reports__editor-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.reports__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.reports__field-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.reports__field-row .reports__field {
+  flex: 1;
+  min-width: 140px;
+}
+
+.reports__field-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.reports__field input {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.55rem;
+  font-size: 0.9rem;
+  color: #111827;
+  background: #f9fafc;
+}
+
+.reports__field input:focus {
+  outline: none;
+  border-color: #2563eb;
+  background: #ffffff;
+}
+
+.reports__weekday {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reports__weekday-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.4rem;
+}
+
+.reports__weekday-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+.reports__weekday-item input {
+  width: 100%;
+  padding: 0.4rem 0.3rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  text-align: center;
+  font-size: 0.85rem;
+  background: #f9fafc;
+}
+
+.reports__editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+@media (max-width: 640px) {
+  .reports {
+    padding: 1rem 0.85rem;
+  }
+
+  .reports__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .reports__header h1 {
+    font-size: 1.3rem;
+  }
+
+  .reports__source-group {
+    align-items: flex-start;
+  }
+
+  .reports__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .reports__chart-card,
+  .reports__table-card {
+    padding: 0.9rem 0.75rem;
+  }
+
+  .reports__chart-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+
+  .reports__weekday-grid {
+    /* 7曜日を2段に折り返して入力しやすく */
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/app/src/features/settings/components/McpTokenSettingsSection/McpTokenSettingsSection.css
+++ b/app/src/features/settings/components/McpTokenSettingsSection/McpTokenSettingsSection.css
@@ -1,0 +1,256 @@
+.mcp-token-settings__status--ready {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.mcp-token-settings__status--warning {
+  background: rgba(245, 158, 11, 0.16);
+  color: #92400e;
+}
+
+.mcp-token-settings__status--neutral {
+  background: rgba(100, 116, 139, 0.14);
+  color: #475569;
+}
+
+.mcp-token-settings__notice {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.mcp-token-settings__alert {
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(239, 68, 68, 0.1);
+  color: #b91c1c;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+.mcp-token-settings__form {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(8rem, 0.6fr);
+  gap: 1rem;
+}
+
+.mcp-token-settings__scopes {
+  grid-column: 1 / -1;
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+}
+
+.mcp-token-settings__scopes legend {
+  color: #4b5563;
+  font-size: 0.9rem;
+  padding: 0 0.25rem;
+}
+
+.mcp-token-settings__scope-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #1f2937;
+  font-size: 0.95rem;
+}
+
+.mcp-token-settings__scope-option input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.mcp-token-settings__form .settings-section__actions {
+  grid-column: 1 / -1;
+}
+
+.mcp-token-settings__issued {
+  border: 1px solid rgba(37, 99, 235, 0.24);
+  border-radius: 0.75rem;
+  background: #f8fbff;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mcp-token-settings__issued textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92rem;
+}
+
+.mcp-token-settings__issued-footer,
+.mcp-token-settings__list-header,
+.mcp-token-settings__token-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.mcp-token-settings__secondary-button,
+.mcp-token-settings__danger-button {
+  border-radius: 0.7rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.55rem 0.85rem;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.mcp-token-settings__secondary-button {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+}
+
+.mcp-token-settings__danger-button {
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  background: #ffffff;
+  color: #b91c1c;
+}
+
+.mcp-token-settings__secondary-button:hover:not(:disabled),
+.mcp-token-settings__danger-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.mcp-token-settings__secondary-button:hover:not(:disabled) {
+  background: #f1f5f9;
+  border-color: #94a3b8;
+}
+
+.mcp-token-settings__danger-button:hover:not(:disabled) {
+  background: #fef2f2;
+  border-color: rgba(185, 28, 28, 0.5);
+}
+
+.mcp-token-settings__secondary-button:disabled,
+.mcp-token-settings__danger-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.mcp-token-settings__secondary-button:focus-visible,
+.mcp-token-settings__danger-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.mcp-token-settings__copy-state {
+  margin: 0;
+  color: #047857;
+  font-size: 0.85rem;
+}
+
+.mcp-token-settings__copy-state--error {
+  color: #b91c1c;
+}
+
+.mcp-token-settings__list-title {
+  margin: 0;
+  color: #1f2937;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.mcp-token-settings__token-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.mcp-token-settings__token-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.mcp-token-settings__token-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.mcp-token-settings__token-name {
+  margin: 0;
+  color: #111827;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.mcp-token-settings__token-scopes {
+  margin: 0.25rem 0 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.mcp-token-settings__token-status {
+  border-radius: 9999px;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.mcp-token-settings__token-status--ready {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.mcp-token-settings__token-status--warning {
+  background: rgba(245, 158, 11, 0.16);
+  color: #92400e;
+}
+
+.mcp-token-settings__token-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.mcp-token-settings__token-meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.mcp-token-settings__token-meta dt {
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.mcp-token-settings__token-meta dd {
+  margin: 0;
+  color: #1f2937;
+  font-size: 0.88rem;
+}
+
+@media (max-width: 768px) {
+  .mcp-token-settings__form,
+  .mcp-token-settings__token-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .mcp-token-settings__issued-footer,
+  .mcp-token-settings__list-header,
+  .mcp-token-settings__token-main {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .mcp-token-settings__issued-footer .settings-section__hint {
+    margin: 0;
+  }
+}

--- a/app/src/features/settings/components/McpTokenSettingsSection/McpTokenSettingsSection.tsx
+++ b/app/src/features/settings/components/McpTokenSettingsSection/McpTokenSettingsSection.tsx
@@ -1,0 +1,370 @@
+import {
+  type CreateMcpTokenPayload,
+  type CreateMcpTokenResponse,
+  MCP_TOKEN_SCOPES,
+  type McpToken,
+  type McpTokenScope,
+} from '@infra/mcp';
+import type React from 'react';
+import { useMemo, useState } from 'react';
+import './McpTokenSettingsSection.css';
+
+type AuthStatus = 'disabled' | 'loading' | 'authenticated' | 'unauthenticated';
+
+export type McpTokenSettingsSectionProps = {
+  authStatus: AuthStatus;
+  isAvailable: boolean;
+  tokens: McpToken[];
+  isLoading?: boolean;
+  isRefreshing?: boolean;
+  error?: unknown;
+  onCreate: (payload: CreateMcpTokenPayload) => Promise<CreateMcpTokenResponse>;
+  onRevoke: (tokenId: string) => Promise<McpToken>;
+  isCreating?: boolean;
+  revokingTokenId?: string | null;
+  onRefresh?: () => void | Promise<void>;
+};
+
+const SCOPE_LABELS: Record<McpTokenScope, string> = {
+  'time-tracker:read': '読み取り',
+  'time-tracker:write': '書き込み',
+};
+
+const DEFAULT_TOKEN_NAME = 'Codex MCP';
+const DEFAULT_EXPIRES_IN_DAYS = '90';
+const MAX_EXPIRES_IN_DAYS = 365;
+
+const formatDate = (value: string | null): string => {
+  if (!value) {
+    return '-';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const resolveStatus = (
+  isAvailable: boolean,
+  authStatus: AuthStatus,
+): { label: string; tone: 'ready' | 'warning' | 'neutral' } => {
+  if (!isAvailable) {
+    return { label: 'API未設定', tone: 'warning' };
+  }
+  if (authStatus === 'loading') {
+    return { label: '確認中', tone: 'neutral' };
+  }
+  if (authStatus === 'authenticated') {
+    return { label: '利用可能', tone: 'ready' };
+  }
+  return { label: '未ログイン', tone: 'warning' };
+};
+
+const resolveTokenStatus = (token: McpToken): { label: string; tone: 'ready' | 'warning' } => {
+  if (token.revokedAt) {
+    return { label: '失効済み', tone: 'warning' };
+  }
+  if (Date.parse(token.expiresAt) <= Date.now()) {
+    return { label: '期限切れ', tone: 'warning' };
+  }
+  return { label: '有効', tone: 'ready' };
+};
+
+const getErrorMessage = (error: unknown): string | null => {
+  if (!error) {
+    return null;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'MCP token の操作に失敗しました。';
+};
+
+export const McpTokenSettingsSection: React.FC<McpTokenSettingsSectionProps> = ({
+  authStatus,
+  isAvailable,
+  tokens,
+  isLoading = false,
+  isRefreshing = false,
+  error,
+  onCreate,
+  onRevoke,
+  isCreating = false,
+  revokingTokenId = null,
+  onRefresh,
+}) => {
+  const [name, setName] = useState(DEFAULT_TOKEN_NAME);
+  const [expiresInDays, setExpiresInDays] = useState(DEFAULT_EXPIRES_IN_DAYS);
+  const [selectedScopes, setSelectedScopes] = useState<McpTokenScope[]>([...MCP_TOKEN_SCOPES]);
+  const [issuedToken, setIssuedToken] = useState<CreateMcpTokenResponse | null>(null);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const sectionStatus = resolveStatus(isAvailable, authStatus);
+  const isAuthenticated = authStatus === 'authenticated';
+  const parsedExpiresInDays = Number(expiresInDays);
+  const normalizedScopes = useMemo(
+    () => MCP_TOKEN_SCOPES.filter((scope) => selectedScopes.includes(scope)),
+    [selectedScopes],
+  );
+  const isExpiresInDaysValid =
+    Number.isFinite(parsedExpiresInDays) &&
+    parsedExpiresInDays >= 1 &&
+    parsedExpiresInDays <= MAX_EXPIRES_IN_DAYS;
+  const createDisabled =
+    !isAvailable ||
+    !isAuthenticated ||
+    isCreating ||
+    name.trim().length === 0 ||
+    normalizedScopes.length === 0 ||
+    !isExpiresInDaysValid;
+  const visibleError = localError ?? getErrorMessage(error);
+
+  const handleScopeChange = (scope: McpTokenScope, checked: boolean) => {
+    setSelectedScopes((current) => {
+      if (checked) {
+        return current.includes(scope) ? current : [...current, scope];
+      }
+      return current.filter((item) => item !== scope);
+    });
+  };
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (createDisabled) {
+      return;
+    }
+
+    setLocalError(null);
+    setCopyState('idle');
+    try {
+      const response = await onCreate({
+        name: name.trim(),
+        scopes: normalizedScopes,
+        expiresInDays: Math.floor(parsedExpiresInDays),
+      });
+      setIssuedToken(response);
+    } catch {
+      setLocalError('MCP token の発行に失敗しました。');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!issuedToken) {
+      return;
+    }
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      setCopyState('failed');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(issuedToken.token);
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed');
+    }
+  };
+
+  const handleRevoke = async (tokenId: string) => {
+    setLocalError(null);
+    try {
+      await onRevoke(tokenId);
+    } catch {
+      setLocalError('MCP token の失効に失敗しました。');
+    }
+  };
+
+  return (
+    <section className="settings-section mcp-token-settings" aria-labelledby="mcp-token-title">
+      <header className="settings-section__header">
+        <div>
+          <h2 id="mcp-token-title" className="settings-section__title">
+            MCP token
+          </h2>
+          <p className="settings-section__description">
+            ローカル MCP クライアントから Time Tracker API を利用する token を管理します。
+          </p>
+        </div>
+        <div
+          className={`settings-section__status mcp-token-settings__status--${sectionStatus.tone}`}
+          aria-live="polite"
+        >
+          {sectionStatus.label}
+        </div>
+      </header>
+
+      {!isAvailable ? (
+        <div className="settings-section__body">
+          <p className="mcp-token-settings__notice">Forge API URL が未設定です。</p>
+        </div>
+      ) : authStatus === 'loading' ? (
+        <div className="settings-section__body">
+          <p className="mcp-token-settings__notice">ログイン状態を確認しています...</p>
+        </div>
+      ) : !isAuthenticated ? (
+        <div className="settings-section__body">
+          <p className="mcp-token-settings__notice">ログイン後に MCP token を管理できます。</p>
+        </div>
+      ) : (
+        <div className="settings-section__body">
+          {visibleError ? (
+            <div className="mcp-token-settings__alert" role="alert">
+              {visibleError}
+            </div>
+          ) : null}
+
+          <form className="mcp-token-settings__form" onSubmit={(event) => void handleCreate(event)}>
+            <div className="time-tracker__field">
+              <label htmlFor="mcp-token-name">名前</label>
+              <input
+                id="mcp-token-name"
+                type="text"
+                value={name}
+                maxLength={80}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+
+            <div className="time-tracker__field">
+              <label htmlFor="mcp-token-expires">有効日数</label>
+              <input
+                id="mcp-token-expires"
+                type="number"
+                min={1}
+                max={MAX_EXPIRES_IN_DAYS}
+                value={expiresInDays}
+                onChange={(event) => setExpiresInDays(event.target.value)}
+              />
+            </div>
+
+            <fieldset className="mcp-token-settings__scopes">
+              <legend>権限</legend>
+              {MCP_TOKEN_SCOPES.map((scope) => (
+                <label key={scope} className="mcp-token-settings__scope-option">
+                  <input
+                    type="checkbox"
+                    checked={selectedScopes.includes(scope)}
+                    onChange={(event) => handleScopeChange(scope, event.target.checked)}
+                  />
+                  <span>{SCOPE_LABELS[scope]}</span>
+                </label>
+              ))}
+            </fieldset>
+
+            <div className="settings-section__actions">
+              <button
+                type="submit"
+                className="settings-section__primary-button"
+                disabled={createDisabled}
+              >
+                {isCreating ? '発行中...' : '発行'}
+              </button>
+            </div>
+          </form>
+
+          {issuedToken ? (
+            <div className="mcp-token-settings__issued" role="status">
+              <div className="time-tracker__field">
+                <label htmlFor="mcp-token-issued-value">発行済み token</label>
+                <textarea id="mcp-token-issued-value" value={issuedToken.token} readOnly rows={2} />
+              </div>
+              <div className="mcp-token-settings__issued-footer">
+                <p className="settings-section__hint">この値は再表示できません。</p>
+                <button
+                  type="button"
+                  className="mcp-token-settings__secondary-button"
+                  onClick={() => void handleCopy()}
+                >
+                  コピー
+                </button>
+              </div>
+              {copyState === 'copied' ? (
+                <p className="mcp-token-settings__copy-state">コピーしました。</p>
+              ) : null}
+              {copyState === 'failed' ? (
+                <p className="mcp-token-settings__copy-state mcp-token-settings__copy-state--error">
+                  コピーできませんでした。
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="mcp-token-settings__list-header">
+            <h3 className="mcp-token-settings__list-title">発行済み token</h3>
+            {onRefresh ? (
+              <button
+                type="button"
+                className="mcp-token-settings__secondary-button"
+                onClick={() => void onRefresh()}
+                disabled={isRefreshing}
+              >
+                {isRefreshing ? '更新中...' : '更新'}
+              </button>
+            ) : null}
+          </div>
+
+          {isLoading ? (
+            <p className="mcp-token-settings__notice">token を読み込んでいます...</p>
+          ) : tokens.length === 0 ? (
+            <p className="mcp-token-settings__notice">発行済み token はありません。</p>
+          ) : (
+            <div className="mcp-token-settings__token-list">
+              {tokens.map((token) => {
+                const status = resolveTokenStatus(token);
+                const canRevoke = !token.revokedAt;
+                return (
+                  <article key={token.id} className="mcp-token-settings__token-item">
+                    <div className="mcp-token-settings__token-main">
+                      <div>
+                        <h4 className="mcp-token-settings__token-name">{token.name}</h4>
+                        <p className="mcp-token-settings__token-scopes">
+                          {token.scopes.map((scope) => SCOPE_LABELS[scope] ?? scope).join(' / ')}
+                        </p>
+                      </div>
+                      <span
+                        className={`mcp-token-settings__token-status mcp-token-settings__token-status--${status.tone}`}
+                      >
+                        {status.label}
+                      </span>
+                    </div>
+                    <dl className="mcp-token-settings__token-meta">
+                      <div>
+                        <dt>発行</dt>
+                        <dd>{formatDate(token.createdAt)}</dd>
+                      </div>
+                      <div>
+                        <dt>期限</dt>
+                        <dd>{formatDate(token.expiresAt)}</dd>
+                      </div>
+                      <div>
+                        <dt>最終利用</dt>
+                        <dd>{formatDate(token.lastUsedAt)}</dd>
+                      </div>
+                    </dl>
+                    <div className="mcp-token-settings__token-actions">
+                      <button
+                        type="button"
+                        className="mcp-token-settings__danger-button"
+                        onClick={() => void handleRevoke(token.id)}
+                        disabled={!canRevoke || revokingTokenId === token.id}
+                      >
+                        {revokingTokenId === token.id ? '失効中...' : '失効'}
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/app/src/features/settings/components/McpTokenSettingsSection/__tests__/McpTokenSettingsSection.test.tsx
+++ b/app/src/features/settings/components/McpTokenSettingsSection/__tests__/McpTokenSettingsSection.test.tsx
@@ -1,0 +1,108 @@
+import type { CreateMcpTokenPayload, CreateMcpTokenResponse, McpToken } from '@infra/mcp';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpTokenSettingsSection } from '../McpTokenSettingsSection.tsx';
+
+const tokenFactory = (overrides: Partial<McpToken> = {}): McpToken => ({
+  id: 'token-1',
+  name: 'Codex MCP',
+  scopes: ['time-tracker:read', 'time-tracker:write'],
+  expiresAt: '2099-08-01T00:00:00.000Z',
+  revokedAt: null,
+  lastUsedAt: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('McpTokenSettingsSection', () => {
+  const defaultProps = {
+    authStatus: 'authenticated' as const,
+    isAvailable: true,
+    tokens: [] as McpToken[],
+    onCreate: vi.fn<[CreateMcpTokenPayload], Promise<CreateMcpTokenResponse>>(),
+    onRevoke: vi.fn<[string], Promise<McpToken>>(),
+    onRefresh: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultProps.onCreate.mockResolvedValue({
+      token: 'forge_mcp_raw-token',
+      mcpToken: tokenFactory(),
+    });
+    defaultProps.onRevoke.mockResolvedValue(
+      tokenFactory({ revokedAt: '2026-05-01T01:00:00.000Z' }),
+    );
+  });
+
+  it('renders unavailable state when the Forge API URL is missing', () => {
+    render(<McpTokenSettingsSection {...defaultProps} isAvailable={false} />);
+
+    expect(screen.getByText('API未設定')).toBeInTheDocument();
+    expect(screen.getByText('Forge API URL が未設定です。')).toBeInTheDocument();
+  });
+
+  it('renders login prompt when unauthenticated', () => {
+    render(<McpTokenSettingsSection {...defaultProps} authStatus="unauthenticated" />);
+
+    expect(screen.getByText('未ログイン')).toBeInTheDocument();
+    expect(screen.getByText('ログイン後に MCP token を管理できます。')).toBeInTheDocument();
+  });
+
+  it('creates a token and shows the raw token once', async () => {
+    const user = userEvent.setup();
+    render(<McpTokenSettingsSection {...defaultProps} />);
+
+    await user.clear(screen.getByLabelText('名前'));
+    await user.type(screen.getByLabelText('名前'), 'Local Codex');
+    await user.clear(screen.getByLabelText('有効日数'));
+    await user.type(screen.getByLabelText('有効日数'), '30');
+    await user.click(screen.getByRole('button', { name: '発行' }));
+
+    expect(defaultProps.onCreate).toHaveBeenCalledWith({
+      name: 'Local Codex',
+      scopes: ['time-tracker:read', 'time-tracker:write'],
+      expiresInDays: 30,
+    });
+    expect(await screen.findByLabelText('発行済み token')).toHaveValue('forge_mcp_raw-token');
+    expect(screen.getByText('この値は再表示できません。')).toBeInTheDocument();
+  });
+
+  it('requires at least one scope before creating a token', async () => {
+    const user = userEvent.setup();
+    render(<McpTokenSettingsSection {...defaultProps} />);
+
+    await user.click(screen.getByLabelText('読み取り'));
+    await user.click(screen.getByLabelText('書き込み'));
+
+    expect(screen.getByRole('button', { name: '発行' })).toBeDisabled();
+  });
+
+  it('renders issued token metadata and revokes an active token', async () => {
+    const user = userEvent.setup();
+    const activeToken = tokenFactory({ name: 'Workspace Token' });
+    render(<McpTokenSettingsSection {...defaultProps} tokens={[activeToken]} />);
+
+    expect(screen.getByText('Workspace Token')).toBeInTheDocument();
+    expect(screen.getByText('読み取り / 書き込み')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '失効' }));
+
+    await waitFor(() => {
+      expect(defaultProps.onRevoke).toHaveBeenCalledWith('token-1');
+    });
+  });
+
+  it('does not allow revoking an already revoked token', () => {
+    render(
+      <McpTokenSettingsSection
+        {...defaultProps}
+        tokens={[tokenFactory({ revokedAt: '2026-05-01T01:00:00.000Z' })]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: '失効' })).toBeDisabled();
+  });
+});

--- a/app/src/features/settings/components/McpTokenSettingsSection/index.ts
+++ b/app/src/features/settings/components/McpTokenSettingsSection/index.ts
@@ -1,0 +1,2 @@
+export type { McpTokenSettingsSectionProps } from './McpTokenSettingsSection.tsx';
+export { McpTokenSettingsSection } from './McpTokenSettingsSection.tsx';

--- a/app/src/features/settings/hooks/useMcpTokens.ts
+++ b/app/src/features/settings/hooks/useMcpTokens.ts
@@ -1,0 +1,91 @@
+import { getAccessToken, useAuth } from '@infra/auth';
+import {
+  type CreateMcpTokenPayload,
+  type CreateMcpTokenResponse,
+  createMcpToken,
+  isMcpTokenClientEnabled,
+  type ListMcpTokensResponse,
+  listMcpTokens,
+  type McpToken,
+  revokeMcpToken,
+} from '@infra/mcp';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+export const MCP_TOKENS_QUERY_KEY = ['mcp-tokens'] as const;
+
+export const useMcpTokens = () => {
+  const { status: authStatus } = useAuth();
+  const queryClient = useQueryClient();
+  const isAvailable = isMcpTokenClientEnabled();
+  const isAuthenticated = authStatus === 'authenticated';
+  const isEnabled = isAvailable && isAuthenticated;
+
+  const tokensQuery = useQuery<ListMcpTokensResponse>({
+    queryKey: MCP_TOKENS_QUERY_KEY,
+    enabled: isEnabled,
+    queryFn: async () => {
+      const token = await getAccessToken();
+      return listMcpTokens(token);
+    },
+  });
+
+  const createTokenMutation = useMutation({
+    mutationFn: async (payload: CreateMcpTokenPayload): Promise<CreateMcpTokenResponse> => {
+      const token = await getAccessToken();
+      return createMcpToken(token, payload);
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData<ListMcpTokensResponse>(MCP_TOKENS_QUERY_KEY, (current) => ({
+        tokens: [
+          data.mcpToken,
+          ...(current?.tokens.filter((item) => item.id !== data.mcpToken.id) ?? []),
+        ],
+      }));
+    },
+  });
+
+  const revokeTokenMutation = useMutation({
+    mutationFn: async (tokenId: string): Promise<McpToken> => {
+      const token = await getAccessToken();
+      const response = await revokeMcpToken(token, tokenId);
+      return response.token;
+    },
+    onSuccess: (revokedToken) => {
+      queryClient.setQueryData<ListMcpTokensResponse>(MCP_TOKENS_QUERY_KEY, (current) => ({
+        tokens: current?.tokens.map((item) =>
+          item.id === revokedToken.id ? revokedToken : item,
+        ) ?? [revokedToken],
+      }));
+    },
+  });
+
+  const createToken = useCallback(
+    async (payload: CreateMcpTokenPayload) => createTokenMutation.mutateAsync(payload),
+    [createTokenMutation],
+  );
+
+  const revokeToken = useCallback(
+    async (tokenId: string) => revokeTokenMutation.mutateAsync(tokenId),
+    [revokeTokenMutation],
+  );
+
+  const refetchTokens = useCallback(async () => {
+    await tokensQuery.refetch();
+  }, [tokensQuery]);
+
+  return {
+    authStatus,
+    isAvailable,
+    isAuthenticated,
+    tokens: tokensQuery.data?.tokens ?? [],
+    isLoading: isEnabled && tokensQuery.isLoading,
+    isRefreshing: isEnabled && tokensQuery.isFetching,
+    error: tokensQuery.error ?? createTokenMutation.error ?? revokeTokenMutation.error,
+    createToken,
+    isCreating: createTokenMutation.isPending,
+    revokeToken,
+    revokingTokenId: revokeTokenMutation.isPending ? (revokeTokenMutation.variables ?? null) : null,
+    refetchTokens,
+  };
+};

--- a/app/src/features/settings/pages/SettingsPage/SettingsPage.tsx
+++ b/app/src/features/settings/pages/SettingsPage/SettingsPage.tsx
@@ -3,6 +3,8 @@ import './SettingsPage.css';
 import { useGoogleSpreadsheetOptions } from '@features/time-tracker/hooks/data/useGoogleSpreadsheetOptions.ts';
 import { isGoogleSyncEnabled } from '@infra/config';
 import { GoogleSpreadsheetSettingsSection } from '../../components/GoogleSpreadsheetSettingsSection';
+import { McpTokenSettingsSection } from '../../components/McpTokenSettingsSection';
+import { useMcpTokens } from '../../hooks/useMcpTokens.ts';
 import { buildOAuthRedirectPath } from './oauthRedirectPath.ts';
 
 type FeedbackState = {
@@ -13,6 +15,7 @@ type FeedbackState = {
 export function SettingsPage(): JSX.Element {
   const { settings, updateSelection, isUpdating, fetchSpreadsheets, fetchSheets, startOAuth } =
     useGoogleSpreadsheetOptions();
+  const mcpTokens = useMcpTokens();
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
 
   const handleSave = useCallback(
@@ -106,6 +109,20 @@ export function SettingsPage(): JSX.Element {
             isSaving={isUpdating}
           />
         )}
+
+        <McpTokenSettingsSection
+          authStatus={mcpTokens.authStatus}
+          isAvailable={mcpTokens.isAvailable}
+          tokens={mcpTokens.tokens}
+          isLoading={mcpTokens.isLoading}
+          isRefreshing={mcpTokens.isRefreshing}
+          error={mcpTokens.error}
+          onCreate={mcpTokens.createToken}
+          onRevoke={mcpTokens.revokeToken}
+          isCreating={mcpTokens.isCreating}
+          revokingTokenId={mcpTokens.revokingTokenId}
+          onRefresh={mcpTokens.refetchTokens}
+        />
       </div>
     </main>
   );

--- a/app/src/features/time-tracker/components/HistoryList/HistoryList.test.tsx
+++ b/app/src/features/time-tracker/components/HistoryList/HistoryList.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { TimeTrackerSession } from '../../domain/types.ts';
+import { HistoryList } from './HistoryList.tsx';
+
+const buildSession = (): TimeTrackerSession => ({
+  id: 'session-1',
+  title: 'Forge work-time tracking setup',
+  project: 'yamamoto-ai-workspace',
+  tags: ['work-time-infer', 'backfill', 'codex', 'claude-code', 'latest-start-to-now'],
+  startedAt: new Date(2026, 4, 9, 0, 17).getTime(),
+  endedAt: new Date(2026, 4, 9, 0, 47).getTime(),
+  durationSeconds: 1832,
+});
+
+describe('HistoryList', () => {
+  it('タグを個別の折り返し可能な項目として表示する', () => {
+    render(
+      <HistoryList
+        sessions={[buildSession()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRestart={vi.fn()}
+        isRunning={false}
+      />,
+    );
+
+    expect(screen.getByText('#yamamoto-ai-workspace')).toHaveClass(
+      'time-tracker__history-meta-item',
+    );
+    expect(screen.getByText('#latest-start-to-now')).toHaveClass('time-tracker__history-meta-item');
+    expect(screen.queryByText(/#work-time-infer #backfill/)).not.toBeInTheDocument();
+  });
+
+  it('タグごとの検索は維持する', () => {
+    render(
+      <HistoryList
+        sessions={[buildSession()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRestart={vi.fn()}
+        isRunning={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('searchbox', { name: '最近の記録を検索' }), {
+      target: { value: '#claude-code #latest-start-to-now' },
+    });
+
+    expect(screen.getByText('Forge work-time tracking setup')).toBeInTheDocument();
+  });
+});

--- a/app/src/features/time-tracker/components/HistoryList/HistoryList.tsx
+++ b/app/src/features/time-tracker/components/HistoryList/HistoryList.tsx
@@ -1,7 +1,8 @@
 import { formatTimer } from '@lib/time.ts';
 import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { TimeTrackerSession } from '../../domain/types.ts';
-import { describeHistorySession } from './logic.ts';
+import { describeHistorySession, filterHistorySessions, formatHistoryTimeRange } from './logic.ts';
 
 type HistoryListProps = {
   sessions: TimeTrackerSession[];
@@ -11,6 +12,8 @@ type HistoryListProps = {
   isRunning: boolean;
 };
 
+const HISTORY_PAGE_SIZE = 10;
+
 export const HistoryList: React.FC<HistoryListProps> = ({
   sessions,
   onEdit,
@@ -18,67 +21,139 @@ export const HistoryList: React.FC<HistoryListProps> = ({
   onRestart,
   isRunning,
 }) => {
+  const [query, setQuery] = useState('');
+  const [visibleCount, setVisibleCount] = useState(HISTORY_PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredSessions = useMemo(() => filterHistorySessions(sessions, query), [sessions, query]);
+  const visibleSessions = useMemo(
+    () => filteredSessions.slice(0, visibleCount),
+    [filteredSessions, visibleCount],
+  );
+  const hasMore = visibleCount < filteredSessions.length;
+  const remainingCount = Math.max(0, filteredSessions.length - visibleSessions.length);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((current) => Math.min(current + HISTORY_PAGE_SIZE, filteredSessions.length));
+  }, [filteredSessions.length]);
+
+  const handleQueryChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+    setVisibleCount(HISTORY_PAGE_SIZE);
+  }, []);
+
+  useEffect(() => {
+    if (!hasMore || typeof IntersectionObserver === 'undefined') return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          loadMore();
+        }
+      },
+      { rootMargin: '160px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
+
   if (sessions.length === 0) return null;
 
   return (
     <section className="time-tracker__history" aria-label="最近の記録">
-      <h2>最近の記録</h2>
-      <ul>
-        {sessions.map((session) => {
-          const titleId = `history-session-${session.id}-title`;
-          const descriptionId = `history-session-${session.id}-description`;
-          return (
-            <li
-              key={session.id}
-              className="time-tracker__history-item"
-              aria-labelledby={titleId}
-              aria-describedby={descriptionId}
-            >
-              <span className="time-tracker__sr-only" id={descriptionId}>
-                {describeHistorySession(session)}
-              </span>
-              <div className="time-tracker__history-main">
-                <strong id={titleId}>{session.title}</strong>
-                <span>{formatTimer(session.durationSeconds)}</span>
-              </div>
-              <div className="time-tracker__history-meta">
-                {session.project ? <span>#{session.project}</span> : null}
-                {session.tags?.length ? (
-                  <span>{session.tags.map((tag) => `#${tag}`).join(' ')}</span>
-                ) : null}
-                {session.skill ? <span>@{session.skill}</span> : null}
-              </div>
-              <div className="time-tracker__history-actions">
-                <button
-                  type="button"
-                  className="time-tracker__history-button"
-                  onClick={() => onRestart(session)}
-                  disabled={isRunning}
-                  aria-label={`「${session.title}」を再開始`}
-                >
-                  再開始
-                </button>
-                <button
-                  type="button"
-                  className="time-tracker__history-button"
-                  onClick={() => onEdit(session.id)}
-                  aria-label={`「${session.title}」を編集`}
-                >
-                  編集
-                </button>
-                <button
-                  type="button"
-                  className="time-tracker__history-button time-tracker__history-button--danger"
-                  onClick={() => onDelete(session.id)}
-                  aria-label={`「${session.title}」を削除`}
-                >
-                  削除
-                </button>
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+      <div className="time-tracker__history-header">
+        <h2>最近の記録</h2>
+        <span>
+          {visibleSessions.length}/{filteredSessions.length}
+        </span>
+      </div>
+      <label className="time-tracker__history-search">
+        <span>履歴を検索</span>
+        <input
+          type="search"
+          value={query}
+          onChange={handleQueryChange}
+          placeholder="タイトル・プロジェクト・タグ"
+          aria-label="最近の記録を検索"
+        />
+      </label>
+      {visibleSessions.length === 0 ? (
+        <p className="time-tracker__history-empty" role="status">
+          一致する記録はありません
+        </p>
+      ) : (
+        <ul>
+          {visibleSessions.map((session) => {
+            const titleId = `history-session-${session.id}-title`;
+            const descriptionId = `history-session-${session.id}-description`;
+            return (
+              <li
+                key={session.id}
+                className="time-tracker__history-item"
+                aria-labelledby={titleId}
+                aria-describedby={descriptionId}
+              >
+                <span className="time-tracker__sr-only" id={descriptionId}>
+                  {describeHistorySession(session)}
+                </span>
+                <div className="time-tracker__history-main">
+                  <strong id={titleId}>{session.title}</strong>
+                  <span>{formatTimer(session.durationSeconds)}</span>
+                </div>
+                <div className="time-tracker__history-range">{formatHistoryTimeRange(session)}</div>
+                <div className="time-tracker__history-meta">
+                  {session.project ? (
+                    <span className="time-tracker__history-meta-item">#{session.project}</span>
+                  ) : null}
+                  {session.tags?.map((tag) => (
+                    <span className="time-tracker__history-meta-item" key={tag}>
+                      #{tag}
+                    </span>
+                  ))}
+                  {session.skill ? (
+                    <span className="time-tracker__history-meta-item">@{session.skill}</span>
+                  ) : null}
+                </div>
+                <div className="time-tracker__history-actions">
+                  <button
+                    type="button"
+                    className="time-tracker__history-button"
+                    onClick={() => onRestart(session)}
+                    disabled={isRunning}
+                    aria-label={`「${session.title}」を再開始`}
+                  >
+                    再開始
+                  </button>
+                  <button
+                    type="button"
+                    className="time-tracker__history-button"
+                    onClick={() => onEdit(session.id)}
+                    aria-label={`「${session.title}」を編集`}
+                  >
+                    編集
+                  </button>
+                  <button
+                    type="button"
+                    className="time-tracker__history-button time-tracker__history-button--danger"
+                    onClick={() => onDelete(session.id)}
+                    aria-label={`「${session.title}」を削除`}
+                  >
+                    削除
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {hasMore ? (
+        <div className="time-tracker__history-load-more" ref={sentinelRef}>
+          <button type="button" className="time-tracker__history-button" onClick={loadMore}>
+            さらに表示（残り{remainingCount}件）
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 };

--- a/app/src/features/time-tracker/components/HistoryList/logic.test.ts
+++ b/app/src/features/time-tracker/components/HistoryList/logic.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { TimeTrackerSession } from '../../domain/types.ts';
+import { describeHistorySession, filterHistorySessions, formatHistoryTimeRange } from './logic.ts';
+
+const session = (
+  input: Pick<TimeTrackerSession, 'startedAt' | 'endedAt' | 'durationSeconds'> &
+    Partial<TimeTrackerSession>,
+): TimeTrackerSession => ({
+  id: 'session-1',
+  title: '戦略OS',
+  project: 'AI駆動開発',
+  ...input,
+});
+
+describe('HistoryList logic', () => {
+  it('同日の開始時刻と終了時刻を日付付きで表示する', () => {
+    expect(
+      formatHistoryTimeRange(
+        session({
+          startedAt: new Date(2026, 4, 1, 20, 30).getTime(),
+          endedAt: new Date(2026, 4, 1, 22, 0).getTime(),
+          durationSeconds: 5400,
+        }),
+      ),
+    ).toBe('5/1 20:30 - 22:00');
+  });
+
+  it('日跨ぎの終了時刻には終了日も表示する', () => {
+    expect(
+      formatHistoryTimeRange(
+        session({
+          startedAt: new Date(2026, 4, 1, 23, 30).getTime(),
+          endedAt: new Date(2026, 4, 2, 0, 15).getTime(),
+          durationSeconds: 2700,
+        }),
+      ),
+    ).toBe('5/1 23:30 - 5/2 00:15');
+  });
+
+  it('ARIA説明にも記録時間を含める', () => {
+    expect(
+      describeHistorySession(
+        session({
+          startedAt: new Date(2026, 4, 1, 20, 30).getTime(),
+          endedAt: new Date(2026, 4, 1, 22, 0).getTime(),
+          durationSeconds: 5400,
+        }),
+      ),
+    ).toContain('記録時間 5/1 20:30 - 22:00');
+  });
+
+  it('タイトル、プロジェクト、タグ、メモで履歴を絞り込める', () => {
+    const sessions = [
+      session({
+        id: 'session-1',
+        title: '戦略OS',
+        project: 'AI駆動開発',
+        tags: ['mcp'],
+        notes: 'Forge履歴',
+        startedAt: new Date(2026, 4, 1, 20, 30).getTime(),
+        endedAt: new Date(2026, 4, 1, 22, 0).getTime(),
+        durationSeconds: 5400,
+      }),
+      session({
+        id: 'session-2',
+        title: '読書',
+        project: 'learning',
+        tags: ['book'],
+        notes: '数理最適化',
+        startedAt: new Date(2026, 4, 1, 22, 30).getTime(),
+        endedAt: new Date(2026, 4, 1, 23, 0).getTime(),
+        durationSeconds: 1800,
+      }),
+    ];
+
+    expect(filterHistorySessions(sessions, '#AI駆動開発 #mcp Forge')).toEqual([sessions[0]]);
+    expect(filterHistorySessions(sessions, 'learning book')).toEqual([sessions[1]]);
+  });
+});

--- a/app/src/features/time-tracker/components/HistoryList/logic.ts
+++ b/app/src/features/time-tracker/components/HistoryList/logic.ts
@@ -9,10 +9,62 @@ import type { TimeTrackerSession } from '../../domain/types.ts';
 export function describeHistorySession(session: TimeTrackerSession): string {
   const parts = [
     `タイトル ${session.title}`,
+    `記録時間 ${formatHistoryTimeRange(session)}`,
     `所要時間 ${formatDurationForAria(session.durationSeconds)}`,
   ];
   if (session.project) parts.push(`プロジェクト ${session.project}`);
   if (session.tags?.length) parts.push(`タグ ${session.tags.join('、')}`);
   if (session.skill) parts.push(`スキル ${session.skill}`);
   return parts.join('、');
+}
+
+const pad2 = (value: number) => value.toString().padStart(2, '0');
+
+const formatDate = (date: Date) => `${date.getMonth() + 1}/${date.getDate()}`;
+
+const formatTime = (date: Date) => `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+
+const isSameLocalDate = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+export function formatHistoryTimeRange(session: TimeTrackerSession): string {
+  const start = new Date(session.startedAt);
+  const end = new Date(session.endedAt);
+  const startLabel = `${formatDate(start)} ${formatTime(start)}`;
+  const endLabel = isSameLocalDate(start, end)
+    ? formatTime(end)
+    : `${formatDate(end)} ${formatTime(end)}`;
+  return `${startLabel} - ${endLabel}`;
+}
+
+const normalize = (value: string) => value.trim().toLocaleLowerCase();
+
+const searchableText = (session: TimeTrackerSession) =>
+  [
+    session.title,
+    session.project,
+    session.project ? `#${session.project}` : undefined,
+    session.skill,
+    session.skill ? `@${session.skill}` : undefined,
+    session.notes,
+    ...(session.tags ?? []),
+    ...(session.tags?.map((tag) => `#${tag}`) ?? []),
+    formatHistoryTimeRange(session),
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .toLocaleLowerCase();
+
+export function filterHistorySessions(
+  sessions: TimeTrackerSession[],
+  query: string,
+): TimeTrackerSession[] {
+  const tokens = normalize(query).split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return sessions;
+  return sessions.filter((session) => {
+    const text = searchableText(session);
+    return tokens.every((token) => text.includes(token));
+  });
 }

--- a/app/src/features/time-tracker/index.css
+++ b/app/src/features/time-tracker/index.css
@@ -497,6 +497,7 @@
 .time-tracker__history {
   width: 100%;
   max-width: 640px;
+  box-sizing: border-box;
   text-align: left;
   display: flex;
   flex-direction: column;
@@ -510,16 +511,67 @@
   color: #4b5563;
 }
 
+.time-tracker__history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.time-tracker__history-header span {
+  color: #64748b;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.time-tracker__history-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #475569;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.time-tracker__history-search input {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 2.75rem;
+  border: 1px solid #d9e0eb;
+  border-radius: 0.85rem;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 0.95rem;
+  padding: 0.65rem 0.85rem;
+  outline: none;
+}
+
+.time-tracker__history-search input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.time-tracker__history-empty {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
 .time-tracker__history ul {
   list-style: none;
   margin: 0;
   padding: 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
 }
 
 .time-tracker__history-item {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
   padding: 1rem 1.25rem;
   border-radius: 1.25rem;
   background: #ffffff;
@@ -535,28 +587,50 @@
   align-items: center;
   gap: 1rem;
   font-size: 1rem;
+  min-width: 0;
 }
 
 .time-tracker__history-main strong {
+  min-width: 0;
   font-weight: 600;
   color: #1f2937;
+  overflow-wrap: anywhere;
+}
+
+.time-tracker__history-main span {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .time-tracker__history-meta {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
+  min-width: 0;
   font-size: 0.9rem;
   color: #6b7280;
 }
 
-.time-tracker__history-meta span {
-  white-space: nowrap;
+.time-tracker__history-range {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.time-tracker__history-meta-item {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .time-tracker__history-actions {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.time-tracker__history-load-more {
+  display: flex;
+  justify-content: center;
 }
 
 .time-tracker__history-button {

--- a/app/src/features/time-tracker/pages/TimeTracker/TimeTrackerPage.test.tsx
+++ b/app/src/features/time-tracker/pages/TimeTracker/TimeTrackerPage.test.tsx
@@ -426,9 +426,9 @@ describe('TimeTrackerRoot', () => {
     const storedSession = {
       id: 'stored-1',
       title: '保存済みタスク',
-      startedAt: Date.now() - 60_000,
-      endedAt: Date.now(),
-      durationSeconds: 60,
+      startedAt: new Date(2026, 4, 1, 20, 30).getTime(),
+      endedAt: new Date(2026, 4, 1, 22, 0).getTime(),
+      durationSeconds: 5400,
       project: 'archive',
     };
     window.localStorage.setItem(STORAGE_KEY_SESSIONS, JSON.stringify([storedSession]));
@@ -436,7 +436,41 @@ describe('TimeTrackerRoot', () => {
     renderTimeTrackerPage();
 
     expect(screen.getByText('保存済みタスク')).toBeInTheDocument();
+    expect(screen.getByText('5/1 20:30 - 22:00')).toBeInTheDocument();
+    expect(screen.getByText('90:00')).toBeInTheDocument();
     expect(screen.getByText('#archive')).toBeInTheDocument();
+  });
+
+  it('最近の記録を検索し、追加表示できる', () => {
+    const baseStartedAt = new Date(2026, 4, 1, 20, 0).getTime();
+    const storedSessions = Array.from({ length: 12 }, (_, index) => ({
+      id: `stored-${index + 1}`,
+      title: `履歴 ${index + 1}`,
+      startedAt: baseStartedAt + index * 60_000,
+      endedAt: baseStartedAt + (index + 1) * 60_000,
+      durationSeconds: 60,
+      project: index === 11 ? 'deep-work' : 'archive',
+      tags: index === 11 ? ['focus'] : [`tag-${index + 1}`],
+      notes: index === 11 ? '検索対象メモ' : undefined,
+    }));
+    window.localStorage.setItem(STORAGE_KEY_SESSIONS, JSON.stringify(storedSessions));
+
+    renderTimeTrackerPage();
+
+    const history = screen.getByRole('region', { name: '最近の記録' });
+    expect(within(history).getByText('履歴 1')).toBeInTheDocument();
+    expect(within(history).queryByText('履歴 12')).not.toBeInTheDocument();
+
+    fireEvent.click(within(history).getByRole('button', { name: 'さらに表示（残り2件）' }));
+    expect(within(history).getByText('履歴 12')).toBeInTheDocument();
+
+    fireEvent.change(within(history).getByLabelText('最近の記録を検索'), {
+      target: { value: 'deep-work focus' },
+    });
+
+    expect(within(history).getByText('履歴 12')).toBeInTheDocument();
+    expect(within(history).queryByText('履歴 1')).not.toBeInTheDocument();
+    expect(within(history).getByText('1/1')).toBeInTheDocument();
   });
 
   it('localStorageのランニングセッションを復元する', () => {

--- a/app/src/features/time-tracker/pages/TimeTracker/TimeTrackerPage.tsx
+++ b/app/src/features/time-tracker/pages/TimeTracker/TimeTrackerPage.tsx
@@ -534,9 +534,6 @@ export function TimeTrackerPage() {
     void syncSession(lastSyncedSession);
   }, [lastSyncedSession, syncSession]);
 
-  // 表示用に先頭5件のみに制限
-  const displaySessions = useMemo(() => sessions.slice(0, 5), [sessions]);
-
   const isGoogleConnected = googleSettings.data?.connectionStatus === 'active';
   const settingsButtonLabel = isGoogleConnected ? '⚙️ 設定 (連携中)' : '⚙️ 設定';
 
@@ -640,7 +637,7 @@ export function TimeTrackerPage() {
         />
 
         <HistoryList
-          sessions={displaySessions}
+          sessions={sessions}
           onEdit={handleEditHistory}
           onDelete={handleDeleteHistory}
           onRestart={handleRestartHistory}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -89,6 +89,8 @@ body {
 
 .app-shell__main {
   flex: 1;
+  /* flex 子要素が min-content 幅で突っ張って溢れないように 0 まで縮める許可 */
+  min-width: 0;
   display: flex;
   flex-direction: column;
   background: #f5f7fb;
@@ -97,6 +99,7 @@ body {
 
 .app-shell__content {
   flex: 1;
+  min-width: 0;
   overflow-y: auto;
   min-height: 0;
 }

--- a/app/src/infra/api/mcp/index.ts
+++ b/app/src/infra/api/mcp/index.ts
@@ -1,0 +1,14 @@
+export {
+  type CreateMcpTokenPayload,
+  type CreateMcpTokenResponse,
+  createMcpToken,
+  isMcpTokenClientEnabled,
+  type ListMcpTokensResponse,
+  listMcpTokens,
+  MCP_TOKEN_SCOPES,
+  type McpToken,
+  McpTokenClientError,
+  type McpTokenScope,
+  type RevokeMcpTokenResponse,
+  revokeMcpToken,
+} from '../../impl/mcp/index.ts';

--- a/app/src/infra/api/repository/Budgets/index.ts
+++ b/app/src/infra/api/repository/Budgets/index.ts
@@ -1,0 +1,2 @@
+export { createBudgetsDataSource } from '../../../impl/repository/Budgets/index.ts';
+export type { BudgetsDataSource } from '../../../impl/repository/Budgets/types.ts';

--- a/app/src/infra/api/repository/DailyMetrics/index.ts
+++ b/app/src/infra/api/repository/DailyMetrics/index.ts
@@ -1,0 +1,2 @@
+export { createDailyMetricsDataSource } from '../../../impl/repository/DailyMetrics/index.ts';
+export type { DailyMetricsDataSource } from '../../../impl/repository/DailyMetrics/types.ts';

--- a/app/src/infra/impl/localstorage/jsonListStorage.ts
+++ b/app/src/infra/impl/localstorage/jsonListStorage.ts
@@ -1,0 +1,28 @@
+// 汎用 JSON 配列ストレージ（local モードの予実・デイリー記録で共有）
+
+export const loadJsonList = <T>(key: string, parse: (value: unknown) => T | null): T[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((entry) => parse(entry)).filter((entry): entry is T => entry !== null);
+  } catch (error) {
+    console.warn(`Failed to load ${key}`, error);
+    return [];
+  }
+};
+
+export const saveJsonList = <T>(key: string, items: T[]): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    if (items.length === 0) {
+      window.localStorage.removeItem(key);
+    } else {
+      window.localStorage.setItem(key, JSON.stringify(items));
+    }
+  } catch (error) {
+    console.warn(`Failed to persist ${key}`, error);
+  }
+};

--- a/app/src/infra/impl/mcp/__tests__/mcpTokenClient.test.ts
+++ b/app/src/infra/impl/mcp/__tests__/mcpTokenClient.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMcpToken,
+  listMcpTokens,
+  McpTokenClientError,
+  revokeMcpToken,
+} from '../mcpTokenClient.ts';
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  });
+
+describe('mcpTokenClient', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com/');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('lists MCP token metadata with Supabase bearer auth', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        tokens: [
+          {
+            id: 'token-1',
+            name: 'Codex',
+            scopes: ['time-tracker:read'],
+            expiresAt: '2026-08-01T00:00:00.000Z',
+            revokedAt: null,
+            lastUsedAt: null,
+            createdAt: '2026-05-01T00:00:00.000Z',
+            updatedAt: '2026-05-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    await expect(listMcpTokens('supabase-token')).resolves.toMatchObject({
+      tokens: [{ id: 'token-1', name: 'Codex' }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/mcp/tokens', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer supabase-token',
+        'Content-Type': 'application/json',
+      },
+    });
+  });
+
+  it('creates an MCP token and returns the raw token response', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          token: 'forge_mcp_raw-token',
+          mcpToken: {
+            id: 'token-1',
+            name: 'Codex',
+            scopes: ['time-tracker:read', 'time-tracker:write'],
+            expiresAt: '2026-08-01T00:00:00.000Z',
+            revokedAt: null,
+            lastUsedAt: null,
+            createdAt: '2026-05-01T00:00:00.000Z',
+            updatedAt: '2026-05-01T00:00:00.000Z',
+          },
+        },
+        { status: 201 },
+      ),
+    );
+
+    await expect(
+      createMcpToken('supabase-token', {
+        name: 'Codex',
+        scopes: ['time-tracker:read', 'time-tracker:write'],
+        expiresInDays: 90,
+      }),
+    ).resolves.toMatchObject({ token: 'forge_mcp_raw-token' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/mcp/tokens',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Codex',
+          scopes: ['time-tracker:read', 'time-tracker:write'],
+          expiresInDays: 90,
+        }),
+      }),
+    );
+  });
+
+  it('revokes an MCP token by id', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        token: {
+          id: 'token/1',
+          name: 'Codex',
+          scopes: ['time-tracker:read'],
+          expiresAt: '2026-08-01T00:00:00.000Z',
+          revokedAt: '2026-05-01T01:00:00.000Z',
+          lastUsedAt: null,
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T01:00:00.000Z',
+        },
+      }),
+    );
+
+    await expect(revokeMcpToken('supabase-token', 'token/1')).resolves.toMatchObject({
+      token: { revokedAt: '2026-05-01T01:00:00.000Z' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/mcp/tokens/token%2F1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('throws typed errors with response details', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'bad_request' }, { status: 400 }));
+
+    await expect(listMcpTokens('supabase-token')).rejects.toMatchObject({
+      name: 'McpTokenClientError',
+      status: 400,
+      detail: { error: 'bad_request' },
+    });
+  });
+
+  it('fails before requesting when the API base URL is not configured', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', '');
+
+    await expect(listMcpTokens('supabase-token')).rejects.toBeInstanceOf(McpTokenClientError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/infra/impl/mcp/index.ts
+++ b/app/src/infra/impl/mcp/index.ts
@@ -1,0 +1,14 @@
+export {
+  type CreateMcpTokenPayload,
+  type CreateMcpTokenResponse,
+  createMcpToken,
+  isMcpTokenClientEnabled,
+  type ListMcpTokensResponse,
+  listMcpTokens,
+  MCP_TOKEN_SCOPES,
+  type McpToken,
+  McpTokenClientError,
+  type McpTokenScope,
+  type RevokeMcpTokenResponse,
+  revokeMcpToken,
+} from './mcpTokenClient.ts';

--- a/app/src/infra/impl/mcp/mcpTokenClient.ts
+++ b/app/src/infra/impl/mcp/mcpTokenClient.ts
@@ -1,0 +1,114 @@
+import { buildGoogleSyncUrl, getGoogleSyncApiBaseUrl, isGoogleSyncEnabled } from '@infra/config';
+
+export const MCP_TOKEN_SCOPES = ['time-tracker:read', 'time-tracker:write'] as const;
+
+export type McpTokenScope = (typeof MCP_TOKEN_SCOPES)[number];
+
+export type McpToken = {
+  id: string;
+  name: string;
+  scopes: McpTokenScope[];
+  expiresAt: string;
+  revokedAt: string | null;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ListMcpTokensResponse = {
+  tokens: McpToken[];
+};
+
+export type CreateMcpTokenPayload = {
+  name: string;
+  scopes: McpTokenScope[];
+  expiresInDays: number;
+};
+
+export type CreateMcpTokenResponse = {
+  token: string;
+  mcpToken: McpToken;
+};
+
+export type RevokeMcpTokenResponse = {
+  token: McpToken;
+};
+
+export class McpTokenClientError extends Error {
+  readonly status: number;
+  readonly detail: unknown;
+
+  constructor(message: string, status: number, detail?: unknown) {
+    super(message);
+    this.name = 'McpTokenClientError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+const buildHeaders = (token: string): HeadersInit => ({
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+});
+
+const request = async <T>(token: string, path: string, init: RequestInit = {}): Promise<T> => {
+  if (!isGoogleSyncEnabled()) {
+    throw new McpTokenClientError('Forge API is disabled', 503);
+  }
+
+  const base = getGoogleSyncApiBaseUrl();
+  if (!base) {
+    throw new McpTokenClientError('Forge API base URL is not configured', 500);
+  }
+
+  const response = await fetch(buildGoogleSyncUrl(path), {
+    ...init,
+    headers: {
+      ...buildHeaders(token),
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  if (!response.ok) {
+    let detail: unknown;
+    try {
+      detail = await response.json();
+    } catch {
+      detail = await response.text();
+    }
+    throw new McpTokenClientError(
+      `MCP token request failed (${response.status}) ${JSON.stringify(detail)}`,
+      response.status,
+      detail,
+    );
+  }
+
+  if (response.headers.get('content-type')?.includes('application/json') ?? false) {
+    return (await response.json()) as T;
+  }
+  const text = await response.text();
+  return text as T;
+};
+
+export const listMcpTokens = (token: string): Promise<ListMcpTokensResponse> =>
+  request(token, '/mcp/tokens', { method: 'GET' });
+
+export const createMcpToken = (
+  token: string,
+  payload: CreateMcpTokenPayload,
+): Promise<CreateMcpTokenResponse> =>
+  request(token, '/mcp/tokens', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+
+export const revokeMcpToken = (token: string, tokenId: string): Promise<RevokeMcpTokenResponse> =>
+  request(token, `/mcp/tokens/${encodeURIComponent(tokenId)}`, {
+    method: 'DELETE',
+  });
+
+export const isMcpTokenClientEnabled = (): boolean => isGoogleSyncEnabled();

--- a/app/src/infra/impl/repository/Budgets/index.ts
+++ b/app/src/infra/impl/repository/Budgets/index.ts
@@ -1,0 +1,16 @@
+import { detectTimeDataSourceMode } from '@infra/config';
+import { createBudgetsLocalStorageDataSource } from './localStorageDataSource.ts';
+import { createBudgetsSupabaseDataSource } from './supabaseDataSource.ts';
+import type { BudgetsDataSource, CreateBudgetsDataSourceOptions } from './types.ts';
+
+export const createBudgetsDataSource = (
+  options: CreateBudgetsDataSourceOptions = {},
+): BudgetsDataSource => {
+  const mode = detectTimeDataSourceMode();
+  if (mode === 'supabase') {
+    return createBudgetsSupabaseDataSource(options);
+  }
+  return createBudgetsLocalStorageDataSource();
+};
+
+export type { BudgetsDataSource } from './types.ts';

--- a/app/src/infra/impl/repository/Budgets/localStorageDataSource.ts
+++ b/app/src/infra/impl/repository/Budgets/localStorageDataSource.ts
@@ -1,0 +1,55 @@
+import type { Budget, BudgetInput } from '../../../../features/reports/domain/types.ts';
+import { loadJsonList, saveJsonList } from '../../localstorage/jsonListStorage.ts';
+import type { BudgetsDataSource } from './types.ts';
+
+const STORAGE_KEY = 'forge/budgets';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const parseBudget = (value: unknown): Budget | null => {
+  if (!isRecord(value)) return null;
+  const { id, tag, weekdayMinutes, effectiveFrom } = value;
+  if (typeof id !== 'string' || typeof tag !== 'string' || typeof effectiveFrom !== 'string') {
+    return null;
+  }
+  if (!Array.isArray(weekdayMinutes) || weekdayMinutes.length !== 7) return null;
+  const minutes = weekdayMinutes.map((n) => (typeof n === 'number' && Number.isFinite(n) ? n : 0));
+  return {
+    id,
+    tag,
+    label: typeof value.label === 'string' ? value.label : null,
+    weekdayMinutes: minutes,
+    effectiveFrom,
+    effectiveTo: typeof value.effectiveTo === 'string' ? value.effectiveTo : null,
+  };
+};
+
+const readBudgets = (): Budget[] => loadJsonList(STORAGE_KEY, parseBudget);
+
+const normalizeBudget = (input: BudgetInput): Budget => ({
+  id: input.id ?? crypto.randomUUID(),
+  tag: input.tag.trim(),
+  label: input.label?.trim() ? input.label.trim() : null,
+  weekdayMinutes: input.weekdayMinutes,
+  effectiveFrom: input.effectiveFrom,
+  effectiveTo: input.effectiveTo ?? null,
+});
+
+export const createBudgetsLocalStorageDataSource = (): BudgetsDataSource => ({
+  mode: 'local',
+  listBudgets: async () => readBudgets(),
+  saveBudget: async (input) => {
+    const budget = normalizeBudget(input);
+    const current = readBudgets();
+    const index = current.findIndex((item) => item.id === budget.id);
+    const next =
+      index === -1 ? [...current, budget] : current.map((item, i) => (i === index ? budget : item));
+    saveJsonList(STORAGE_KEY, next);
+    return budget;
+  },
+  deleteBudget: async (id) => {
+    const next = readBudgets().filter((item) => item.id !== id);
+    saveJsonList(STORAGE_KEY, next);
+  },
+});

--- a/app/src/infra/impl/repository/Budgets/supabaseDataSource.ts
+++ b/app/src/infra/impl/repository/Budgets/supabaseDataSource.ts
@@ -1,0 +1,95 @@
+import type { Budget } from '../../../../features/reports/domain/types.ts';
+import { getSupabaseClient } from '../../supabase/client.ts';
+import type { BudgetsDataSource, CreateBudgetsDataSourceOptions } from './types.ts';
+
+const TABLE = 'time_tracker_budgets';
+const SELECT = 'id, tag, label, weekday_minutes, effective_from, effective_to';
+
+type BudgetRow = {
+  id: string;
+  tag: string;
+  label: string | null;
+  weekday_minutes: number[] | null;
+  effective_from: string;
+  effective_to: string | null;
+};
+
+const mapRowToBudget = (row: BudgetRow): Budget => ({
+  id: row.id,
+  tag: row.tag,
+  label: row.label,
+  weekdayMinutes:
+    Array.isArray(row.weekday_minutes) && row.weekday_minutes.length === 7
+      ? row.weekday_minutes
+      : [0, 0, 0, 0, 0, 0, 0],
+  effectiveFrom: row.effective_from,
+  effectiveTo: row.effective_to,
+});
+
+const mapBudgetToRow = (budget: Budget, userId: string) => ({
+  id: budget.id,
+  user_id: userId,
+  tag: budget.tag,
+  label: budget.label ?? null,
+  weekday_minutes: budget.weekdayMinutes,
+  effective_from: budget.effectiveFrom,
+  effective_to: budget.effectiveTo ?? null,
+  updated_at: new Date().toISOString(),
+});
+
+export const createBudgetsSupabaseDataSource = (
+  options: CreateBudgetsDataSourceOptions = {},
+): BudgetsDataSource => {
+  const supabase = getSupabaseClient();
+
+  const resolveUserId = async (): Promise<string | null> => {
+    if (options.userId) return options.userId;
+    const { data, error } = await supabase.auth.getUser();
+    if (error) return null;
+    return data.user?.id ?? null;
+  };
+
+  return {
+    mode: 'supabase',
+    listBudgets: async () => {
+      const userId = await resolveUserId();
+      if (!userId) return [];
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(SELECT)
+        .eq('user_id', userId)
+        .order('effective_from', { ascending: false });
+      if (error) {
+        if (import.meta.env.MODE !== 'test') {
+          // eslint-disable-next-line no-console
+          console.error('[supabase] Failed to fetch budgets', error.message);
+        }
+        return [];
+      }
+      return ((data ?? []) as BudgetRow[]).map(mapRowToBudget);
+    },
+    saveBudget: async (input) => {
+      const userId = await resolveUserId();
+      const budget: Budget = {
+        id: input.id ?? crypto.randomUUID(),
+        tag: input.tag.trim(),
+        label: input.label?.trim() ? input.label.trim() : null,
+        weekdayMinutes: input.weekdayMinutes,
+        effectiveFrom: input.effectiveFrom,
+        effectiveTo: input.effectiveTo ?? null,
+      };
+      if (!userId) return budget;
+      const { error } = await supabase
+        .from(TABLE)
+        .upsert(mapBudgetToRow(budget, userId), { onConflict: 'id' });
+      if (error) throw error;
+      return budget;
+    },
+    deleteBudget: async (id) => {
+      const userId = await resolveUserId();
+      if (!userId) return;
+      const { error } = await supabase.from(TABLE).delete().eq('user_id', userId).eq('id', id);
+      if (error) throw error;
+    },
+  };
+};

--- a/app/src/infra/impl/repository/Budgets/types.ts
+++ b/app/src/infra/impl/repository/Budgets/types.ts
@@ -1,0 +1,12 @@
+import type { Budget, BudgetInput } from '../../../../features/reports/domain/types.ts';
+
+export type BudgetsDataSource = {
+  readonly mode: 'local' | 'supabase';
+  listBudgets: () => Promise<Budget[]>;
+  saveBudget: (input: BudgetInput) => Promise<Budget>;
+  deleteBudget: (id: string) => Promise<void>;
+};
+
+export type CreateBudgetsDataSourceOptions = {
+  userId?: string | null;
+};

--- a/app/src/infra/impl/repository/DailyMetrics/index.ts
+++ b/app/src/infra/impl/repository/DailyMetrics/index.ts
@@ -1,0 +1,16 @@
+import { detectTimeDataSourceMode } from '@infra/config';
+import { createDailyMetricsLocalStorageDataSource } from './localStorageDataSource.ts';
+import { createDailyMetricsSupabaseDataSource } from './supabaseDataSource.ts';
+import type { CreateDailyMetricsDataSourceOptions, DailyMetricsDataSource } from './types.ts';
+
+export const createDailyMetricsDataSource = (
+  options: CreateDailyMetricsDataSourceOptions = {},
+): DailyMetricsDataSource => {
+  const mode = detectTimeDataSourceMode();
+  if (mode === 'supabase') {
+    return createDailyMetricsSupabaseDataSource(options);
+  }
+  return createDailyMetricsLocalStorageDataSource();
+};
+
+export type { DailyMetricsDataSource } from './types.ts';

--- a/app/src/infra/impl/repository/DailyMetrics/localStorageDataSource.ts
+++ b/app/src/infra/impl/repository/DailyMetrics/localStorageDataSource.ts
@@ -1,0 +1,113 @@
+import type {
+  MetricDefinition,
+  MetricDefinitionInput,
+  MetricEntry,
+  MetricKind,
+  MetricValue,
+} from '../../../../features/daily-log/domain/types.ts';
+import { loadJsonList, saveJsonList } from '../../localstorage/jsonListStorage.ts';
+import type { DailyMetricsDataSource } from './types.ts';
+
+const DEFINITIONS_KEY = 'forge/daily-metric-definitions';
+const ENTRIES_KEY = 'forge/daily-metric-entries';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const KINDS = new Set<MetricKind>(['boolean', 'number', 'single_select', 'multi_select']);
+
+const parseDefinition = (value: unknown): MetricDefinition | null => {
+  if (!isRecord(value)) return null;
+  const { id, name, kind } = value;
+  if (typeof id !== 'string' || typeof name !== 'string') return null;
+  if (typeof kind !== 'string' || !KINDS.has(kind as MetricKind)) return null;
+  return {
+    id,
+    name,
+    kind: kind as MetricKind,
+    unit: typeof value.unit === 'string' ? value.unit : null,
+    options: Array.isArray(value.options) ? (value.options as MetricDefinition['options']) : null,
+    targetNumber: typeof value.targetNumber === 'number' ? value.targetNumber : null,
+    displayOrder: typeof value.displayOrder === 'number' ? value.displayOrder : 0,
+    archivedAt: typeof value.archivedAt === 'string' ? value.archivedAt : null,
+  };
+};
+
+const parseEntry = (value: unknown): MetricEntry | null => {
+  if (!isRecord(value)) return null;
+  const { id, metricId, entryDate } = value;
+  if (typeof id !== 'string' || typeof metricId !== 'string' || typeof entryDate !== 'string') {
+    return null;
+  }
+  return { id, metricId, entryDate, value: value.value as MetricValue };
+};
+
+const readDefinitions = (): MetricDefinition[] => loadJsonList(DEFINITIONS_KEY, parseDefinition);
+const readEntries = (): MetricEntry[] => loadJsonList(ENTRIES_KEY, parseEntry);
+
+const normalizeDefinition = (input: MetricDefinitionInput): MetricDefinition => ({
+  id: input.id ?? crypto.randomUUID(),
+  name: input.name.trim(),
+  kind: input.kind,
+  unit: input.unit?.trim() ? input.unit.trim() : null,
+  options: input.options ?? null,
+  targetNumber: input.targetNumber ?? null,
+  displayOrder: input.displayOrder,
+  archivedAt: input.archivedAt ?? null,
+});
+
+export const createDailyMetricsLocalStorageDataSource = (): DailyMetricsDataSource => ({
+  mode: 'local',
+  listDefinitions: async () =>
+    readDefinitions()
+      .filter((definition) => !definition.archivedAt)
+      .sort((a, b) => a.displayOrder - b.displayOrder),
+  saveDefinition: async (input) => {
+    const definition = normalizeDefinition(input);
+    const current = readDefinitions();
+    const index = current.findIndex((item) => item.id === definition.id);
+    const next =
+      index === -1
+        ? [...current, definition]
+        : current.map((item, i) => (i === index ? definition : item));
+    saveJsonList(DEFINITIONS_KEY, next);
+    return definition;
+  },
+  deleteDefinition: async (id) => {
+    saveJsonList(
+      DEFINITIONS_KEY,
+      readDefinitions().filter((item) => item.id !== id),
+    );
+    // 関連する記録も削除
+    saveJsonList(
+      ENTRIES_KEY,
+      readEntries().filter((entry) => entry.metricId !== id),
+    );
+  },
+  listEntries: async (fromKey, toKey) =>
+    readEntries().filter((entry) => entry.entryDate >= fromKey && entry.entryDate <= toKey),
+  upsertEntry: async (input) => {
+    const current = readEntries();
+    const index = current.findIndex(
+      (entry) => entry.metricId === input.metricId && entry.entryDate === input.entryDate,
+    );
+    const entry: MetricEntry = {
+      id: input.id ?? (index === -1 ? crypto.randomUUID() : current[index].id),
+      metricId: input.metricId,
+      entryDate: input.entryDate,
+      value: input.value,
+    };
+    const next =
+      index === -1 ? [...current, entry] : current.map((item, i) => (i === index ? entry : item));
+    saveJsonList(ENTRIES_KEY, next);
+    return entry;
+  },
+  deleteEntry: async (metricId, entryDate) => {
+    saveJsonList(
+      ENTRIES_KEY,
+      readEntries().filter(
+        (entry) => !(entry.metricId === metricId && entry.entryDate === entryDate),
+      ),
+    );
+  },
+});

--- a/app/src/infra/impl/repository/DailyMetrics/supabaseDataSource.ts
+++ b/app/src/infra/impl/repository/DailyMetrics/supabaseDataSource.ts
@@ -1,0 +1,182 @@
+import type {
+  MetricDefinition,
+  MetricEntry,
+  MetricKind,
+  MetricValue,
+} from '../../../../features/daily-log/domain/types.ts';
+import { getSupabaseClient } from '../../supabase/client.ts';
+import type { CreateDailyMetricsDataSourceOptions, DailyMetricsDataSource } from './types.ts';
+
+const DEFINITIONS_TABLE = 'daily_metric_definitions';
+const ENTRIES_TABLE = 'daily_metric_entries';
+const DEFINITION_SELECT =
+  'id, name, kind, unit, options, target_number, display_order, archived_at';
+const ENTRY_SELECT = 'id, metric_id, entry_date, value';
+
+type DefinitionRow = {
+  id: string;
+  name: string;
+  kind: MetricKind;
+  unit: string | null;
+  options: MetricDefinition['options'];
+  target_number: number | null;
+  display_order: number | null;
+  archived_at: string | null;
+};
+
+type EntryRow = {
+  id: string;
+  metric_id: string;
+  entry_date: string;
+  value: MetricValue;
+};
+
+const mapRowToDefinition = (row: DefinitionRow): MetricDefinition => ({
+  id: row.id,
+  name: row.name,
+  kind: row.kind,
+  unit: row.unit,
+  options: row.options ?? null,
+  targetNumber: row.target_number,
+  displayOrder: row.display_order ?? 0,
+  archivedAt: row.archived_at,
+});
+
+const mapRowToEntry = (row: EntryRow): MetricEntry => ({
+  id: row.id,
+  metricId: row.metric_id,
+  entryDate: row.entry_date,
+  value: row.value,
+});
+
+export const createDailyMetricsSupabaseDataSource = (
+  options: CreateDailyMetricsDataSourceOptions = {},
+): DailyMetricsDataSource => {
+  const supabase = getSupabaseClient();
+
+  const resolveUserId = async (): Promise<string | null> => {
+    if (options.userId) return options.userId;
+    const { data, error } = await supabase.auth.getUser();
+    if (error) return null;
+    return data.user?.id ?? null;
+  };
+
+  const logError = (message: string, detail: string) => {
+    if (import.meta.env.MODE !== 'test') {
+      // eslint-disable-next-line no-console
+      console.error(message, detail);
+    }
+  };
+
+  return {
+    mode: 'supabase',
+    listDefinitions: async () => {
+      const userId = await resolveUserId();
+      if (!userId) return [];
+      const { data, error } = await supabase
+        .from(DEFINITIONS_TABLE)
+        .select(DEFINITION_SELECT)
+        .eq('user_id', userId)
+        .is('archived_at', null)
+        .order('display_order', { ascending: true });
+      if (error) {
+        logError('[supabase] Failed to fetch metric definitions', error.message);
+        return [];
+      }
+      return ((data ?? []) as DefinitionRow[]).map(mapRowToDefinition);
+    },
+    saveDefinition: async (input) => {
+      const userId = await resolveUserId();
+      const definition: MetricDefinition = {
+        id: input.id ?? crypto.randomUUID(),
+        name: input.name.trim(),
+        kind: input.kind,
+        unit: input.unit?.trim() ? input.unit.trim() : null,
+        options: input.options ?? null,
+        targetNumber: input.targetNumber ?? null,
+        displayOrder: input.displayOrder,
+        archivedAt: input.archivedAt ?? null,
+      };
+      if (!userId) return definition;
+      const { error } = await supabase.from(DEFINITIONS_TABLE).upsert(
+        {
+          id: definition.id,
+          user_id: userId,
+          name: definition.name,
+          kind: definition.kind,
+          unit: definition.unit,
+          options: definition.options,
+          target_number: definition.targetNumber,
+          display_order: definition.displayOrder,
+          archived_at: definition.archivedAt,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'id' },
+      );
+      if (error) throw error;
+      return definition;
+    },
+    deleteDefinition: async (id) => {
+      const userId = await resolveUserId();
+      if (!userId) return;
+      const { error } = await supabase
+        .from(DEFINITIONS_TABLE)
+        .delete()
+        .eq('user_id', userId)
+        .eq('id', id);
+      if (error) throw error;
+    },
+    listEntries: async (fromKey, toKey) => {
+      const userId = await resolveUserId();
+      if (!userId) return [];
+      const { data, error } = await supabase
+        .from(ENTRIES_TABLE)
+        .select(ENTRY_SELECT)
+        .eq('user_id', userId)
+        .gte('entry_date', fromKey)
+        .lte('entry_date', toKey);
+      if (error) {
+        logError('[supabase] Failed to fetch metric entries', error.message);
+        return [];
+      }
+      return ((data ?? []) as EntryRow[]).map(mapRowToEntry);
+    },
+    upsertEntry: async (input) => {
+      const userId = await resolveUserId();
+      const entry: MetricEntry = {
+        id: input.id ?? crypto.randomUUID(),
+        metricId: input.metricId,
+        entryDate: input.entryDate,
+        value: input.value,
+      };
+      if (!userId) return entry;
+      const { data, error } = await supabase
+        .from(ENTRIES_TABLE)
+        .upsert(
+          {
+            user_id: userId,
+            metric_id: entry.metricId,
+            entry_date: entry.entryDate,
+            value: entry.value,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: 'user_id,metric_id,entry_date' },
+        )
+        .select(ENTRY_SELECT)
+        .maybeSingle();
+      if (error) throw error;
+      return data ? mapRowToEntry(data as EntryRow) : entry;
+    },
+    deleteEntry: async (metricId, entryDate) => {
+      const userId = await resolveUserId();
+      if (!userId) return;
+      const { error } = await supabase
+        .from(ENTRIES_TABLE)
+        .delete()
+        .eq('user_id', userId)
+        .eq('metric_id', metricId)
+        .eq('entry_date', entryDate);
+      if (error) throw error;
+    },
+  };
+};

--- a/app/src/infra/impl/repository/DailyMetrics/types.ts
+++ b/app/src/infra/impl/repository/DailyMetrics/types.ts
@@ -1,0 +1,20 @@
+import type {
+  MetricDefinition,
+  MetricDefinitionInput,
+  MetricEntry,
+  MetricEntryInput,
+} from '../../../../features/daily-log/domain/types.ts';
+
+export type DailyMetricsDataSource = {
+  readonly mode: 'local' | 'supabase';
+  listDefinitions: () => Promise<MetricDefinition[]>;
+  saveDefinition: (input: MetricDefinitionInput) => Promise<MetricDefinition>;
+  deleteDefinition: (id: string) => Promise<void>;
+  listEntries: (fromKey: string, toKey: string) => Promise<MetricEntry[]>;
+  upsertEntry: (input: MetricEntryInput) => Promise<MetricEntry>;
+  deleteEntry: (metricId: string, entryDate: string) => Promise<void>;
+};
+
+export type CreateDailyMetricsDataSourceOptions = {
+  userId?: string | null;
+};

--- a/app/src/lib/date.test.ts
+++ b/app/src/lib/date.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { formatDateTimeLocal, parseDateTimeLocal } from './date';
+import {
+  addDays,
+  dateKeyToDate,
+  eachDayKey,
+  formatDateTimeLocal,
+  monthStartKey,
+  parseDateTimeLocal,
+  toDateKey,
+  weekdayIndex,
+  weekStartKey,
+} from './date';
 
 describe('date', () => {
   describe('formatDateTimeLocal', () => {
@@ -54,6 +64,56 @@ describe('date', () => {
 
     it('無効な日時文字列はnullを返す', () => {
       expect(parseDateTimeLocal('invalid-date')).toBeNull();
+    });
+  });
+
+  describe('日付キーユーティリティ', () => {
+    it('ローカル日付を YYYY-MM-DD に変換する', () => {
+      const ts = new Date(2025, 0, 6, 9, 30).getTime();
+      expect(toDateKey(ts)).toBe('2025-01-06');
+    });
+
+    it('日付キーをローカル日の Date に戻せる', () => {
+      const date = dateKeyToDate('2025-01-06');
+      expect(date.getFullYear()).toBe(2025);
+      expect(date.getMonth()).toBe(0);
+      expect(date.getDate()).toBe(6);
+    });
+
+    it('日付を加算・減算できる（月境界をまたぐ）', () => {
+      expect(addDays('2025-01-31', 1)).toBe('2025-02-01');
+      expect(addDays('2025-03-01', -1)).toBe('2025-02-28');
+    });
+
+    it('両端を含む日付キーを昇順で列挙する', () => {
+      expect(eachDayKey('2025-01-06', '2025-01-09')).toEqual([
+        '2025-01-06',
+        '2025-01-07',
+        '2025-01-08',
+        '2025-01-09',
+      ]);
+    });
+
+    it('from > to のとき空配列を返す', () => {
+      expect(eachDayKey('2025-01-09', '2025-01-06')).toEqual([]);
+    });
+
+    it('曜日インデックスは 0=日曜', () => {
+      expect(weekdayIndex('2025-01-05')).toBe(0);
+      expect(weekdayIndex('2025-01-06')).toBe(1);
+    });
+
+    it('週開始日は既定で月曜', () => {
+      expect(weekStartKey('2025-01-09')).toBe('2025-01-06');
+      expect(weekStartKey('2025-01-06')).toBe('2025-01-06');
+    });
+
+    it('週開始日を日曜にもできる', () => {
+      expect(weekStartKey('2025-01-09', 0)).toBe('2025-01-05');
+    });
+
+    it('月初日キーを返す', () => {
+      expect(monthStartKey('2025-01-20')).toBe('2025-01-01');
     });
   });
 });

--- a/app/src/lib/date.ts
+++ b/app/src/lib/date.ts
@@ -11,3 +11,70 @@ export const parseDateTimeLocal = (value: string): number | null => {
   const time = parsed.getTime();
   return Number.isNaN(time) ? null : time;
 };
+
+// =====================================================================
+// 日付キー（'YYYY-MM-DD' ローカル日）ユーティリティ
+// 予実集計・デイリー記録で日単位のバケットに使う純粋関数群。
+// 文字列 'YYYY-MM-DD' は辞書順 = 日付順なので比較・ソートにそのまま使える。
+// =====================================================================
+
+/** タイムスタンプ / Date をローカルタイムゾーンの 'YYYY-MM-DD' に変換する。 */
+export const toDateKey = (input: number | Date): string => {
+  const date = typeof input === 'number' ? new Date(input) : input;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/** 'YYYY-MM-DD' をローカル日の Date（00:00 ローカル）に変換する。 */
+export const dateKeyToDate = (key: string): Date => {
+  const [year, month, day] = key.split('-').map((part) => Number(part));
+  return new Date(year ?? 1970, (month ?? 1) - 1, day ?? 1);
+};
+
+/** 日付キーに days 日加算した日付キーを返す（負数も可）。 */
+export const addDays = (key: string, days: number): string => {
+  const date = dateKeyToDate(key);
+  date.setDate(date.getDate() + days);
+  return toDateKey(date);
+};
+
+/** fromKey〜toKey（両端含む）の日付キーを昇順で列挙する。 */
+export const eachDayKey = (fromKey: string, toKey: string): string[] => {
+  const result: string[] = [];
+  if (fromKey > toKey) return result;
+  let current = fromKey;
+  // 無限ループ保護（約270年分）
+  for (let guard = 0; current <= toKey && guard < 100_000; guard += 1) {
+    result.push(current);
+    current = addDays(current, 1);
+  }
+  return result;
+};
+
+/** 曜日インデックス（0=日曜, JS Date.getDay() 準拠）。 */
+export const weekdayIndex = (key: string): number => dateKeyToDate(key).getDay();
+
+/** その日が属する週の開始日キー。weekStartsOn は 0=日曜 / 1=月曜（既定）。 */
+export const weekStartKey = (key: string, weekStartsOn = 1): string => {
+  const diff = (weekdayIndex(key) - weekStartsOn + 7) % 7;
+  return addDays(key, -diff);
+};
+
+/** その日が属する月の初日キー（'YYYY-MM-01'）。 */
+export const monthStartKey = (key: string): string => `${key.slice(0, 7)}-01`;
+
+/** 日付キーに months か月加算（月末は自動繰り上がり）。 */
+export const addMonths = (key: string, months: number): string => {
+  const date = dateKeyToDate(key);
+  date.setMonth(date.getMonth() + months);
+  return toDateKey(date);
+};
+
+/** 2つの日付キーの差（日数, fromKey 基準で toKey までの日数）。 */
+export const diffDays = (fromKey: string, toKey: string): number => {
+  const from = dateKeyToDate(fromKey).getTime();
+  const to = dateKeyToDate(toKey).getTime();
+  return Math.round((to - from) / 86_400_000);
+};

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -3,7 +3,9 @@ import React, { type ReactNode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import './index.css';
+import { DailyLogPage } from '@features/daily-log';
 import { AuthLoading, LoginPage } from '@features/login';
+import { ReportsPage } from '@features/reports';
 import { SettingsPage } from '@features/settings';
 import { TimeTrackerPage } from '@features/time-tracker';
 import { useTimeTrackerSessions } from '@features/time-tracker/hooks/data/useTimeTrackerSessions.ts';
@@ -78,6 +80,8 @@ function AppRoutes(): JSX.Element {
       >
         <Route index element={<Navigate to="/time-tracker" replace />} />
         <Route path="time-tracker" element={<TimeTrackerPage />} />
+        <Route path="reports" element={<ReportsPage />} />
+        <Route path="daily-log" element={<DailyLogPage />} />
         <Route path="settings" element={<SettingsPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/app/src/ui/components/LineChart/LineChart.css
+++ b/app/src/ui/components/LineChart/LineChart.css
@@ -1,0 +1,84 @@
+.line-chart {
+  position: relative;
+  width: 100%;
+}
+
+.line-chart__svg {
+  display: block;
+  width: 100%;
+}
+
+.line-chart__grid {
+  stroke: #e2e8f0;
+  stroke-width: 1;
+}
+
+.line-chart__y-label {
+  fill: #94a3b8;
+  font-size: 11px;
+  text-anchor: end;
+}
+
+.line-chart__x-label {
+  fill: #94a3b8;
+  font-size: 11px;
+  text-anchor: middle;
+}
+
+.line-chart__guide {
+  stroke: #cbd5e1;
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+}
+
+.line-chart__tooltip {
+  position: absolute;
+  top: 12px;
+  transform: translateX(-50%);
+  min-width: 120px;
+  padding: 0.5rem 0.65rem;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  border-radius: 0.5rem;
+  font-size: 0.78rem;
+  pointer-events: none;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.25);
+  z-index: 2;
+}
+
+.line-chart__tooltip--right {
+  transform: translateX(12px);
+}
+
+.line-chart__tooltip--left {
+  transform: translateX(calc(-100% - 12px));
+}
+
+.line-chart__tooltip-title {
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.line-chart__tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  line-height: 1.6;
+}
+
+.line-chart__tooltip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+.line-chart__tooltip-label {
+  flex: 1;
+  color: #cbd5e1;
+}
+
+.line-chart__tooltip-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}

--- a/app/src/ui/components/LineChart/LineChart.tsx
+++ b/app/src/ui/components/LineChart/LineChart.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import './LineChart.css';
+
+export type ChartSeries = {
+  id: string;
+  label: string;
+  color: string;
+  /** labels と同じ長さ。未計測点は null（線を途切れさせる）。 */
+  values: (number | null)[];
+};
+
+export type LineChartProps = {
+  labels: string[];
+  series: ChartSeries[];
+  height?: number;
+  /** y 軸・ツールチップの数値整形 */
+  formatValue?: (value: number) => string;
+  /** 'zero' は 0 基準（累積向け）、'auto' はデータ範囲に合わせて調整（推移向け）。 */
+  yBaseline?: 'zero' | 'auto';
+  ariaLabel?: string;
+};
+
+const PADDING = { top: 16, right: 16, bottom: 28, left: 52 };
+const DEFAULT_HEIGHT = 280;
+
+const niceNum = (range: number, round: boolean): number => {
+  if (range <= 0) return 1;
+  const exponent = Math.floor(Math.log10(range));
+  const fraction = range / 10 ** exponent;
+  let niceFraction: number;
+  if (round) {
+    niceFraction = fraction < 1.5 ? 1 : fraction < 3 ? 2 : fraction < 7 ? 5 : 10;
+  } else {
+    niceFraction = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10;
+  }
+  return niceFraction * 10 ** exponent;
+};
+
+/** データ範囲から「きれいな」下限・上限・刻みを求める。 */
+const computeBounds = (
+  min: number,
+  max: number,
+  baseline: 'zero' | 'auto',
+): { lo: number; hi: number; step: number } => {
+  let lo = min;
+  let hi = max;
+  if (baseline === 'zero') {
+    lo = Math.min(0, min);
+  } else if (lo === hi) {
+    // 単一値: 上下に少し余白
+    const pad = Math.abs(lo) > 0 ? Math.abs(lo) * 0.1 : 1;
+    lo -= pad;
+    hi += pad;
+  }
+  const range = niceNum(hi - lo, false);
+  const step = niceNum(range / 4, true);
+  return {
+    lo: Math.floor(lo / step) * step,
+    hi: Math.ceil(hi / step) * step,
+    step,
+  };
+};
+
+const defaultFormat = (value: number): string => `${Math.round(value)}`;
+
+export function LineChart({
+  labels,
+  series,
+  height = DEFAULT_HEIGHT,
+  formatValue = defaultFormat,
+  yBaseline = 'auto',
+  ariaLabel,
+}: LineChartProps): JSX.Element {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(640);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const clipId = useId();
+
+  useEffect(() => {
+    const node = wrapperRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(Math.max(320, entry.contentRect.width));
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const count = labels.length;
+  const plotWidth = Math.max(1, width - PADDING.left - PADDING.right);
+  const plotHeight = Math.max(1, height - PADDING.top - PADDING.bottom);
+
+  const allValues = series.flatMap((s) => s.values.filter((v): v is number => v != null));
+  const dataMin = allValues.length > 0 ? Math.min(...allValues) : 0;
+  const dataMax = allValues.length > 0 ? Math.max(...allValues) : 1;
+  const { lo, hi, step } = computeBounds(dataMin, dataMax, yBaseline);
+  const span = hi - lo || 1;
+
+  const xFor = useCallback(
+    (index: number): number => {
+      if (count <= 1) return PADDING.left + plotWidth / 2;
+      return PADDING.left + (plotWidth * index) / (count - 1);
+    },
+    [count, plotWidth],
+  );
+  const yFor = useCallback(
+    (value: number): number => PADDING.top + plotHeight * (1 - (value - lo) / span),
+    [plotHeight, lo, span],
+  );
+
+  const ticks: number[] = [];
+  for (let tick = lo; tick <= hi + step / 2; tick += step) {
+    ticks.push(tick);
+  }
+
+  const handlePointer = useCallback(
+    (event: React.PointerEvent<SVGRectElement>) => {
+      if (count === 0) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const offsetX = event.clientX - rect.left;
+      const ratio = plotWidth <= 0 ? 0 : offsetX / plotWidth;
+      const index = Math.round(ratio * (count - 1));
+      setActiveIndex(Math.min(count - 1, Math.max(0, index)));
+    },
+    [count, plotWidth],
+  );
+
+  const buildPath = (values: (number | null)[]): string => {
+    let path = '';
+    let penUp = true;
+    values.forEach((value, index) => {
+      if (value == null) {
+        penUp = true;
+        return;
+      }
+      const command = penUp ? 'M' : 'L';
+      path += `${command}${xFor(index).toFixed(1)},${yFor(value).toFixed(1)} `;
+      penUp = false;
+    });
+    return path.trim();
+  };
+
+  const xLabelStep = Math.max(1, Math.ceil(count / 8));
+  const tooltipLeft = activeIndex != null ? xFor(activeIndex) : 0;
+  const tooltipOnRight = tooltipLeft < width / 2;
+
+  return (
+    <div className="line-chart" ref={wrapperRef}>
+      <svg
+        width={width}
+        height={height}
+        role="img"
+        aria-label={ariaLabel ?? 'チャート'}
+        className="line-chart__svg"
+      >
+        <title>{ariaLabel ?? 'チャート'}</title>
+        <defs>
+          <clipPath id={clipId}>
+            <rect x={PADDING.left} y={PADDING.top} width={plotWidth} height={plotHeight} />
+          </clipPath>
+        </defs>
+
+        {/* 横グリッド + y 目盛 */}
+        {ticks.map((tick) => (
+          <g key={tick}>
+            <line
+              x1={PADDING.left}
+              x2={PADDING.left + plotWidth}
+              y1={yFor(tick)}
+              y2={yFor(tick)}
+              className="line-chart__grid"
+            />
+            <text x={PADDING.left - 8} y={yFor(tick) + 4} className="line-chart__y-label">
+              {formatValue(tick)}
+            </text>
+          </g>
+        ))}
+
+        {/* x ラベル（位置 cx をキーに使い、配列 index をキーに含めない） */}
+        {labels.map((label, index) => {
+          if (index % xLabelStep !== 0) return null;
+          const cx = xFor(index);
+          return (
+            <text key={`${label}-${cx}`} x={cx} y={height - 8} className="line-chart__x-label">
+              {label}
+            </text>
+          );
+        })}
+
+        {/* 系列線（孤立点はドットで描画して見えるようにする） */}
+        <g clipPath={`url(#${clipId})`}>
+          {series.map((s) => (
+            <path key={s.id} d={buildPath(s.values)} fill="none" stroke={s.color} strokeWidth={2} />
+          ))}
+          {series.flatMap((s) =>
+            s.values.map((value, index) => {
+              if (value == null) return null;
+              const prev = index > 0 ? s.values[index - 1] : null;
+              const next = index < s.values.length - 1 ? s.values[index + 1] : null;
+              if (prev != null || next != null) return null;
+              const cx = xFor(index);
+              return (
+                <circle key={`${s.id}-dot-${cx}`} cx={cx} cy={yFor(value)} r={3} fill={s.color} />
+              );
+            }),
+          )}
+        </g>
+
+        {/* ホバーガイド */}
+        {activeIndex != null ? (
+          <g>
+            <line
+              x1={xFor(activeIndex)}
+              x2={xFor(activeIndex)}
+              y1={PADDING.top}
+              y2={PADDING.top + plotHeight}
+              className="line-chart__guide"
+            />
+            {series.map((s) => {
+              const value = s.values[activeIndex];
+              if (value == null) return null;
+              return (
+                <circle
+                  key={s.id}
+                  cx={xFor(activeIndex)}
+                  cy={yFor(value)}
+                  r={3.5}
+                  fill={s.color}
+                  stroke="var(--line-chart-dot-stroke, #ffffff)"
+                  strokeWidth={1.5}
+                />
+              );
+            })}
+          </g>
+        ) : null}
+
+        {/* ポインタ捕捉 */}
+        <rect
+          x={PADDING.left}
+          y={PADDING.top}
+          width={plotWidth}
+          height={plotHeight}
+          fill="transparent"
+          onPointerMove={handlePointer}
+          onPointerLeave={() => setActiveIndex(null)}
+        />
+      </svg>
+
+      {activeIndex != null ? (
+        <div
+          className={`line-chart__tooltip ${tooltipOnRight ? 'line-chart__tooltip--right' : 'line-chart__tooltip--left'}`}
+          style={{ left: `${tooltipLeft}px` }}
+          role="status"
+        >
+          <div className="line-chart__tooltip-title">{labels[activeIndex]}</div>
+          {series.map((s) => {
+            const value = s.values[activeIndex];
+            return (
+              <div key={s.id} className="line-chart__tooltip-row">
+                <span className="line-chart__tooltip-dot" style={{ background: s.color }} />
+                <span className="line-chart__tooltip-label">{s.label}</span>
+                <span className="line-chart__tooltip-value">
+                  {value == null ? '—' : formatValue(value)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/ui/components/LineChart/index.ts
+++ b/app/src/ui/components/LineChart/index.ts
@@ -1,0 +1,2 @@
+export type { ChartSeries, LineChartProps } from './LineChart.tsx';
+export { LineChart } from './LineChart.tsx';

--- a/app/src/ui/components/RangeControl/RangeControl.css
+++ b/app/src/ui/components/RangeControl/RangeControl.css
@@ -1,0 +1,100 @@
+.range-control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.range-control__nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.range-control__arrow {
+  width: 32px;
+  height: 32px;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #475569;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.range-control__arrow:hover:not(:disabled) {
+  background: #f1f5f9;
+}
+
+.range-control__arrow:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.range-control__dates {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.range-control__date {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  font-size: 0.82rem;
+  color: #111827;
+  background: #f9fafc;
+}
+
+.range-control__date:focus {
+  outline: none;
+  border-color: #2563eb;
+  background: #ffffff;
+}
+
+.range-control__tilde {
+  color: #94a3b8;
+  font-size: 0.8rem;
+}
+
+.range-control__presets {
+  display: inline-flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.range-control__preset {
+  padding: 0.35rem 0.7rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 9999px;
+  background: #ffffff;
+  color: #475569;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.range-control__preset:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+@media (max-width: 640px) {
+  .range-control {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .range-control__nav {
+    justify-content: space-between;
+  }
+
+  .range-control__dates {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .range-control__date {
+    flex: 1;
+    min-width: 0;
+  }
+}

--- a/app/src/ui/components/RangeControl/RangeControl.tsx
+++ b/app/src/ui/components/RangeControl/RangeControl.tsx
@@ -1,0 +1,115 @@
+import { addDays, addMonths, diffDays } from '@lib/date.ts';
+import './RangeControl.css';
+
+export type RangeControlProps = {
+  fromKey: string;
+  toKey: string;
+  todayKey: string;
+  onChange: (fromKey: string, toKey: string) => void;
+};
+
+type SpanPreset = { label: string; days?: number; months?: number };
+
+const SPAN_PRESETS: SpanPreset[] = [
+  { label: '1週間', days: 7 },
+  { label: '2週間', days: 14 },
+  { label: '1か月', months: 1 },
+  { label: '3か月', months: 3 },
+  { label: '6か月', months: 6 },
+  { label: '1年', months: 12 },
+  { label: '2年', months: 24 },
+];
+
+export function RangeControl({
+  fromKey,
+  toKey,
+  todayKey,
+  onChange,
+}: RangeControlProps): JSX.Element {
+  const spanDays = diffDays(fromKey, toKey) + 1;
+
+  const shift = (deltaDays: number) => {
+    let nextFrom = addDays(fromKey, deltaDays);
+    let nextTo = addDays(toKey, deltaDays);
+    if (nextTo > todayKey) {
+      nextTo = todayKey;
+      nextFrom = addDays(todayKey, -(spanDays - 1));
+    }
+    onChange(nextFrom, nextTo);
+  };
+
+  const applyPreset = (preset: SpanPreset) => {
+    const nextFrom =
+      preset.days !== undefined
+        ? addDays(todayKey, -(preset.days - 1))
+        : addDays(addMonths(todayKey, -(preset.months ?? 1)), 1);
+    onChange(nextFrom, todayKey);
+  };
+
+  const handleFrom = (value: string) => {
+    if (!value) return;
+    onChange(value > toKey ? toKey : value, toKey);
+  };
+  const handleTo = (value: string) => {
+    if (!value) return;
+    const clamped = value > todayKey ? todayKey : value;
+    onChange(fromKey > clamped ? clamped : fromKey, clamped);
+  };
+
+  return (
+    <div className="range-control">
+      <div className="range-control__nav">
+        <button
+          type="button"
+          className="range-control__arrow"
+          onClick={() => shift(-spanDays)}
+          aria-label="前の期間へ"
+          title="前の期間へ"
+        >
+          ◀
+        </button>
+        <div className="range-control__dates">
+          <input
+            type="date"
+            className="range-control__date"
+            value={fromKey}
+            max={toKey}
+            onChange={(event) => handleFrom(event.target.value)}
+            aria-label="開始日"
+          />
+          <span className="range-control__tilde">〜</span>
+          <input
+            type="date"
+            className="range-control__date"
+            value={toKey}
+            max={todayKey}
+            onChange={(event) => handleTo(event.target.value)}
+            aria-label="終了日"
+          />
+        </div>
+        <button
+          type="button"
+          className="range-control__arrow"
+          onClick={() => shift(spanDays)}
+          disabled={toKey >= todayKey}
+          aria-label="次の期間へ"
+          title="次の期間へ"
+        >
+          ▶
+        </button>
+      </div>
+      <div className="range-control__presets">
+        {SPAN_PRESETS.map((preset) => (
+          <button
+            key={preset.label}
+            type="button"
+            className="range-control__preset"
+            onClick={() => applyPreset(preset)}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/ui/components/RangeControl/index.ts
+++ b/app/src/ui/components/RangeControl/index.ts
@@ -1,0 +1,2 @@
+export type { RangeControlProps } from './RangeControl.tsx';
+export { RangeControl } from './RangeControl.tsx';

--- a/app/src/ui/layouts/AppNav.tsx
+++ b/app/src/ui/layouts/AppNav.tsx
@@ -29,6 +29,30 @@ const AppNavList: React.FC<NavListProps> = ({ onSelect }) => {
         Time Tracker
       </NavLink>
       <NavLink
+        to="/reports"
+        end
+        className={({ isActive }) =>
+          ['app-shell__nav-item', isActive ? 'app-shell__nav-item--active' : null]
+            .filter(Boolean)
+            .join(' ')
+        }
+        onClick={handleSelect}
+      >
+        レポート
+      </NavLink>
+      <NavLink
+        to="/daily-log"
+        end
+        className={({ isActive }) =>
+          ['app-shell__nav-item', isActive ? 'app-shell__nav-item--active' : null]
+            .filter(Boolean)
+            .join(' ')
+        }
+        onClick={handleSelect}
+      >
+        デイリー記録
+      </NavLink>
+      <NavLink
         to="/settings"
         end
         className={({ isActive }) =>
@@ -40,9 +64,6 @@ const AppNavList: React.FC<NavListProps> = ({ onSelect }) => {
       >
         設定
       </NavLink>
-      <button type="button" className="app-shell__nav-item" disabled>
-        レポート (準備中)
-      </button>
     </nav>
   );
 };

--- a/app/tests/e2e/daily-log.spec.ts
+++ b/app/tests/e2e/daily-log.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+test('チェックボックス項目を追加して当日を記録できる', async ({ page }) => {
+  await page.goto('/daily-log');
+  await expect(page.getByRole('heading', { name: 'デイリー記録' })).toBeVisible();
+
+  await page.getByRole('button', { name: '項目を追加' }).click();
+  await page.getByLabel('項目名').fill('ジムで運動する');
+  // 入力の種類は既定でチェックボックス
+  await page.getByRole('button', { name: '保存' }).click();
+
+  // 列ヘッダー（編集ボタン）と当日のチェックボックスが出る
+  await expect(page.getByRole('button', { name: 'ジムで運動する' })).toBeVisible();
+
+  // チェックは remote クエリで制御されるため、click 後に retry 付きで反映を待つ
+  const todayCheckbox = page.getByRole('checkbox').first();
+  await todayCheckbox.click();
+  await expect(todayCheckbox).toBeChecked();
+});
+
+test('数値項目を追加して記録すると推移グラフが表示される', async ({ page }) => {
+  await page.goto('/daily-log');
+
+  await page.getByRole('button', { name: '項目を追加' }).click();
+  await page.getByLabel('項目名').fill('体重');
+  await page.getByLabel('入力の種類').selectOption('number');
+  await page.getByLabel('単位（任意）').fill('kg');
+  await page.getByRole('button', { name: '保存' }).click();
+
+  // 当日の数値セルに入力して確定
+  const numberCell = page.getByRole('spinbutton').first();
+  await numberCell.fill('62.5');
+  await numberCell.blur();
+  await expect(numberCell).toHaveValue('62.5');
+
+  // 推移グラフが表示される
+  await expect(page.getByRole('img', { name: '体重の推移' })).toBeVisible();
+});
+
+test('選択ボックス項目は選択肢から記録できる', async ({ page }) => {
+  await page.goto('/daily-log');
+
+  await page.getByRole('button', { name: '項目を追加' }).click();
+  await page.getByLabel('項目名').fill('体調');
+  await page.getByLabel('入力の種類').selectOption('single_select');
+  await page.getByLabel('選択肢（1行に1つ）').fill('良い\n普通\n悪い');
+  await page.getByRole('button', { name: '保存' }).click();
+
+  // 列が追加され、当日のセル（select）で選べる
+  await expect(page.getByRole('button', { name: '体調' })).toBeVisible();
+  const select = page.getByRole('combobox').first();
+  await select.selectOption('良い');
+  await expect(select).toHaveValue('良い');
+});

--- a/app/tests/e2e/reports.spec.ts
+++ b/app/tests/e2e/reports.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+const addBudget = async (page: import('@playwright/test').Page) => {
+  await page.getByRole('button', { name: '予算を追加' }).click();
+  await page.getByLabel('対象プロジェクト').fill('鍛錬');
+  await page.getByLabel('月曜日の予算（時間）').fill('3');
+  await page.getByRole('button', { name: '保存' }).click();
+};
+
+test('プロジェクトに曜日別予算を設定すると予実グラフと表が表示される', async ({ page }) => {
+  await page.goto('/reports');
+  await expect(page.getByRole('heading', { name: 'レポート' })).toBeVisible();
+
+  await addBudget(page);
+
+  // 予実ソースのタブ・累積グラフ・予実差テーブルが出る
+  await expect(page.getByRole('tab', { name: '鍛錬' })).toBeVisible();
+  await expect(page.getByRole('img', { name: '累積時間の予算と実績' })).toBeVisible();
+  await expect(page.getByText('予実差').first()).toBeVisible();
+});
+
+test('週次・月次・日次に切り替えると集計単位が変わる', async ({ page }) => {
+  await page.goto('/reports');
+  await addBudget(page);
+
+  // 既定は週次
+  await expect(page.getByRole('tab', { name: '週次' })).toHaveAttribute('aria-selected', 'true');
+
+  await page.getByRole('tab', { name: '月次' }).click();
+  await expect(page.getByRole('tab', { name: '月次' })).toHaveAttribute('aria-selected', 'true');
+
+  await page.getByRole('tab', { name: '日次' }).click();
+  await expect(page.getByRole('tab', { name: '日次' })).toHaveAttribute('aria-selected', 'true');
+});
+
+test('期間プリセットで表示レンジを切り替えられる', async ({ page }) => {
+  await page.goto('/reports');
+  await addBudget(page);
+
+  // 期間プリセット（1週間〜2年）が表示され、押せる
+  await expect(page.getByRole('button', { name: '2年' })).toBeVisible();
+  await page.getByRole('button', { name: '1週間' }).click();
+  // グラフは引き続き表示される
+  await expect(page.getByRole('img', { name: '累積時間の予算と実績' })).toBeVisible();
+});

--- a/db/migrations/003_forge_mcp_tokens.sql
+++ b/db/migrations/003_forge_mcp_tokens.sql
@@ -1,0 +1,80 @@
+-- Forge remote HTTP MCP bearer token metadata.
+-- Token raw values are returned only once by the Worker and only token_hash is stored.
+
+create table if not exists public.forge_mcp_tokens (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    name text not null,
+    token_hash text not null unique,
+    scopes text[] not null default array['time-tracker:read', 'time-tracker:write'],
+    expires_at timestamptz not null,
+    revoked_at timestamptz default null,
+    last_used_at timestamptz default null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint forge_mcp_tokens_name_not_blank check (length(btrim(name)) > 0),
+    constraint forge_mcp_tokens_scopes_not_empty check (array_length(scopes, 1) > 0),
+    constraint forge_mcp_tokens_scopes_allowed
+        check (scopes <@ array['time-tracker:read', 'time-tracker:write'])
+);
+
+create index if not exists forge_mcp_tokens_user_id_idx
+    on public.forge_mcp_tokens(user_id);
+
+create index if not exists forge_mcp_tokens_token_hash_idx
+    on public.forge_mcp_tokens(token_hash);
+
+alter table if exists public.forge_mcp_tokens enable row level security;
+
+do $$
+begin
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_select_own'
+    ) then
+        create policy forge_mcp_tokens_select_own
+            on public.forge_mcp_tokens
+            for select
+            using (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_insert_own'
+    ) then
+        create policy forge_mcp_tokens_insert_own
+            on public.forge_mcp_tokens
+            for insert
+            with check (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_update_own'
+    ) then
+        create policy forge_mcp_tokens_update_own
+            on public.forge_mcp_tokens
+            for update
+            using (auth.uid() = user_id)
+            with check (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_delete_own'
+    ) then
+        create policy forge_mcp_tokens_delete_own
+            on public.forge_mcp_tokens
+            for delete
+            using (auth.uid() = user_id);
+    end if;
+end;
+$$;

--- a/db/migrations/004_budgets_and_daily_metrics.sql
+++ b/db/migrations/004_budgets_and_daily_metrics.sql
@@ -1,0 +1,110 @@
+-- 予実管理（プロジェクト/タグ単位・曜日別予算）とデイリーカスタム記録。
+-- 実績はアプリ側で time_tracker_sessions を集計して導出する。
+-- 冪等（create if not exists + ポリシー存在チェック）なので再適用しても安全。
+
+-- =====================================================================
+-- 予実（プロジェクト/タグ単位・曜日別スケジュール）
+-- =====================================================================
+create table if not exists public.time_tracker_budgets (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    tag text not null,
+    label text default null,
+    -- 長さ7。index 0 = 日曜（JS Date.getDay() 準拠）の1日あたり予算「分」
+    weekday_minutes integer[] not null default array[0, 0, 0, 0, 0, 0, 0],
+    effective_from date not null,
+    effective_to date default null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint time_tracker_budgets_tag_not_blank check (length(btrim(tag)) > 0),
+    constraint time_tracker_budgets_weekday_minutes_len
+        check (array_length(weekday_minutes, 1) = 7),
+    constraint time_tracker_budgets_effective_range
+        check (effective_to is null or effective_to >= effective_from)
+);
+
+create index if not exists time_tracker_budgets_user_id_idx
+    on public.time_tracker_budgets(user_id);
+
+-- =====================================================================
+-- デイリーカスタム記録（チェック/数値/テキスト/選択。選択式は value=jsonb で吸収）
+-- =====================================================================
+create table if not exists public.daily_metric_definitions (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    name text not null,
+    kind text not null check (kind in ('boolean', 'number', 'text', 'single_select', 'multi_select')),
+    unit text default null,
+    options jsonb default null,
+    target_number numeric default null,
+    display_order integer not null default 0,
+    archived_at timestamptz default null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint daily_metric_definitions_name_not_blank check (length(btrim(name)) > 0)
+);
+
+create index if not exists daily_metric_definitions_user_id_idx
+    on public.daily_metric_definitions(user_id);
+
+create table if not exists public.daily_metric_entries (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    metric_id uuid not null references public.daily_metric_definitions(id) on delete cascade,
+    entry_date date not null,
+    value jsonb not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint daily_metric_entries_unique_per_day unique (user_id, metric_id, entry_date)
+);
+
+create index if not exists daily_metric_entries_user_id_idx
+    on public.daily_metric_entries(user_id);
+create index if not exists daily_metric_entries_metric_date_idx
+    on public.daily_metric_entries(metric_id, entry_date);
+
+-- RLS（own-rows のみ）
+alter table if exists public.time_tracker_budgets enable row level security;
+alter table if exists public.daily_metric_definitions enable row level security;
+alter table if exists public.daily_metric_entries enable row level security;
+
+do $$
+declare
+    tbl text;
+    op text;
+    policy_name text;
+begin
+    foreach tbl in array array[
+        'time_tracker_budgets',
+        'daily_metric_definitions',
+        'daily_metric_entries'
+    ]
+    loop
+        foreach op in array array['select', 'insert', 'update', 'delete']
+        loop
+            policy_name := format('%s_%s_own', tbl, op);
+            if not exists (
+                select 1 from pg_policies
+                where schemaname = 'public' and tablename = tbl and policyname = policy_name
+            ) then
+                if op = 'insert' then
+                    execute format(
+                        'create policy %I on public.%I for insert with check (auth.uid() = user_id)',
+                        policy_name, tbl
+                    );
+                elsif op = 'update' then
+                    execute format(
+                        'create policy %I on public.%I for update using (auth.uid() = user_id) with check (auth.uid() = user_id)',
+                        policy_name, tbl
+                    );
+                else
+                    execute format(
+                        'create policy %I on public.%I for %s using (auth.uid() = user_id)',
+                        policy_name, tbl, op
+                    );
+                end if;
+            end if;
+        end loop;
+    end loop;
+end;
+$$;

--- a/db/tables.sql
+++ b/db/tables.sql
@@ -25,9 +25,34 @@ create table if not exists time_tracker_running_states (
     updated_at timestamptz not null default now()
     );
 
+-- MCP bearer tokens for remote HTTP MCP clients.
+create table if not exists public.forge_mcp_tokens (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    name text not null,
+    token_hash text not null unique,
+    scopes text[] not null default array['time-tracker:read', 'time-tracker:write'],
+    expires_at timestamptz not null,
+    revoked_at timestamptz default null,
+    last_used_at timestamptz default null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint forge_mcp_tokens_name_not_blank check (length(btrim(name)) > 0),
+    constraint forge_mcp_tokens_scopes_not_empty check (array_length(scopes, 1) > 0),
+    constraint forge_mcp_tokens_scopes_allowed
+        check (scopes <@ array['time-tracker:read', 'time-tracker:write'])
+);
+
+create index if not exists forge_mcp_tokens_user_id_idx
+    on public.forge_mcp_tokens(user_id);
+
+create index if not exists forge_mcp_tokens_token_hash_idx
+    on public.forge_mcp_tokens(token_hash);
+
 -- RLS 設定
 alter table if exists public.time_tracker_sessions enable row level security;
 alter table if exists public.time_tracker_running_states enable row level security;
+alter table if exists public.forge_mcp_tokens enable row level security;
 
 do $$
 begin
@@ -125,6 +150,55 @@ begin
     ) then
         create policy time_tracker_running_states_delete_own
             on public.time_tracker_running_states
+            for delete
+            using (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_select_own'
+    ) then
+        create policy forge_mcp_tokens_select_own
+            on public.forge_mcp_tokens
+            for select
+            using (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_insert_own'
+    ) then
+        create policy forge_mcp_tokens_insert_own
+            on public.forge_mcp_tokens
+            for insert
+            with check (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_update_own'
+    ) then
+        create policy forge_mcp_tokens_update_own
+            on public.forge_mcp_tokens
+            for update
+            using (auth.uid() = user_id)
+            with check (auth.uid() = user_id);
+    end if;
+
+    if not exists (
+        select 1 from pg_policies
+        where schemaname = 'public'
+          and tablename = 'forge_mcp_tokens'
+          and policyname = 'forge_mcp_tokens_delete_own'
+    ) then
+        create policy forge_mcp_tokens_delete_own
+            on public.forge_mcp_tokens
             for delete
             using (auth.uid() = user_id);
     end if;

--- a/db/tables.sql
+++ b/db/tables.sql
@@ -204,3 +204,117 @@ begin
     end if;
 end;
 $$;
+
+-- =====================================================================
+-- 予実管理（タグ単位・曜日別スケジュール）
+-- =====================================================================
+-- 対象タグごとに「曜日別の1日あたり予算（分）」と有効期間を持つ。
+-- 実績はアプリ側で time_tracker_sessions を日次集計して導出する。
+create table if not exists public.time_tracker_budgets (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    tag text not null,
+    label text default null,
+    -- 長さ7。index 0 = 日曜（JS Date.getDay() 準拠）の1日あたり予算「分」
+    weekday_minutes integer[] not null default array[0, 0, 0, 0, 0, 0, 0],
+    effective_from date not null,
+    effective_to date default null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint time_tracker_budgets_tag_not_blank check (length(btrim(tag)) > 0),
+    constraint time_tracker_budgets_weekday_minutes_len
+        check (array_length(weekday_minutes, 1) = 7),
+    constraint time_tracker_budgets_effective_range
+        check (effective_to is null or effective_to >= effective_from)
+);
+
+create index if not exists time_tracker_budgets_user_id_idx
+    on public.time_tracker_budgets(user_id);
+
+-- =====================================================================
+-- デイリーカスタム記録（真偽 / 数値を実装。選択式は value=jsonb で土台のみ）
+-- =====================================================================
+create table if not exists public.daily_metric_definitions (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    name text not null,
+    kind text not null check (kind in ('boolean', 'number', 'text', 'single_select', 'multi_select')),
+    unit text default null,
+    options jsonb default null,        -- 選択式の [{value,label}]（将来用）
+    target_number numeric default null, -- 数値項目の目標値（将来の予実化フック）
+    display_order integer not null default 0,
+    archived_at timestamptz default null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint daily_metric_definitions_name_not_blank check (length(btrim(name)) > 0)
+);
+
+create index if not exists daily_metric_definitions_user_id_idx
+    on public.daily_metric_definitions(user_id);
+
+create table if not exists public.daily_metric_entries (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    metric_id uuid not null references public.daily_metric_definitions(id) on delete cascade,
+    entry_date date not null,
+    -- boolean: true/false / number: 数値 / single_select: "v" / multi_select: ["a","b"]
+    value jsonb not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint daily_metric_entries_unique_per_day unique (user_id, metric_id, entry_date)
+);
+
+create index if not exists daily_metric_entries_user_id_idx
+    on public.daily_metric_entries(user_id);
+create index if not exists daily_metric_entries_metric_date_idx
+    on public.daily_metric_entries(metric_id, entry_date);
+
+-- RLS 設定（予実・デイリー記録）
+alter table if exists public.time_tracker_budgets enable row level security;
+alter table if exists public.daily_metric_definitions enable row level security;
+alter table if exists public.daily_metric_entries enable row level security;
+
+do $$
+declare
+    tbl text;
+    op text;
+    policy_name text;
+    using_clause text;
+    check_clause text;
+begin
+    foreach tbl in array array[
+        'time_tracker_budgets',
+        'daily_metric_definitions',
+        'daily_metric_entries'
+    ]
+    loop
+        foreach op in array array['select', 'insert', 'update', 'delete']
+        loop
+            policy_name := format('%s_%s_own', tbl, op);
+            if not exists (
+                select 1 from pg_policies
+                where schemaname = 'public'
+                  and tablename = tbl
+                  and policyname = policy_name
+            ) then
+                if op = 'insert' then
+                    execute format(
+                        'create policy %I on public.%I for insert with check (auth.uid() = user_id)',
+                        policy_name, tbl
+                    );
+                elsif op = 'update' then
+                    execute format(
+                        'create policy %I on public.%I for update using (auth.uid() = user_id) with check (auth.uid() = user_id)',
+                        policy_name, tbl
+                    );
+                else
+                    execute format(
+                        'create policy %I on public.%I for %s using (auth.uid() = user_id)',
+                        policy_name, tbl, op
+                    );
+                end if;
+            end if;
+        end loop;
+    end loop;
+end;
+$$;

--- a/docs/runbooks/remote-http-mcp.md
+++ b/docs/runbooks/remote-http-mcp.md
@@ -1,0 +1,64 @@
+# Remote HTTP MCP
+
+Forge Worker exposes a stateless remote MCP endpoint for Time Tracker operations.
+
+## Secrets
+
+Set this Worker secret before deploying code that uses `/mcp` or `/mcp/tokens`:
+
+- `MCP_TOKEN_HASH_PEPPER`: HMAC pepper for hashing `forge_mcp_...` bearer tokens before Supabase storage.
+
+The raw MCP token is never stored. `forge_mcp_tokens.token_hash` stores only the peppered HMAC-SHA-256 digest.
+
+## Database
+
+Apply `db/migrations/003_forge_mcp_tokens.sql`.
+
+The table stores token metadata:
+
+- `user_id`
+- `name`
+- `token_hash`
+- `scopes`
+- `expires_at`
+- `revoked_at`
+- `last_used_at`
+
+RLS policies restrict direct Supabase access to the owning user. The Worker still uses the service role key and must enforce user ownership in repository filters.
+
+## Token API
+
+Token management uses the normal Forge/Supabase access token:
+
+```bash
+curl -X POST "$FORGE_API_BASE/mcp/tokens" \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Codex","scopes":["time-tracker:read","time-tracker:write"],"expiresInDays":90}'
+```
+
+The response includes the raw `token` only once. Store it in the MCP client secret store, not in Git.
+
+Other endpoints:
+
+- `GET /mcp/tokens`
+- `DELETE /mcp/tokens/:id`
+
+## MCP Endpoint
+
+MCP clients call:
+
+```text
+POST /mcp
+Authorization: Bearer forge_mcp_...
+Content-Type: application/json
+```
+
+Supported tools:
+
+- `ForgeTimeTrackerStart`
+- `ForgeTimeTrackerStatus`
+- `ForgeTimeTrackerStop`
+- `ForgeTimeTrackerCancel`
+
+`ForgeTimeTrackerStop` records the session in Supabase and then attempts the existing Google Sheets sync. If Google reconnect is required, the session remains recorded and the `sync` field reports the failure/skipped reason.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.27)(jsdom@24.1.3)
+      wrangler:
+        specifier: ^4.42.2
+        version: 4.54.0(@cloudflare/workers-types@4.20260101.0)
 
 packages:
 


### PR DESCRIPTION
## Summary
- add remote HTTP MCP endpoint for Forge time tracker
- add scoped forge_mcp bearer token create/list/revoke APIs
- store only peppered token hashes in Supabase
- add migration and runbook for rollout

## Verification
- pnpm --filter api test:run
- pnpm --filter api exec tsc --noEmit
- pnpm lint
- pnpm exec biome check api/src api/tsconfig.json db/tables.sql db/migrations/003_forge_mcp_tokens.sql
- bun run ai:verify

## Rollout notes
- apply db/migrations/003_forge_mcp_tokens.sql
- set Worker secret MCP_TOKEN_HASH_PEPPER
- deploy Worker
- issue an MCP token via POST /mcp/tokens