### PR TITLE
chore: add `pnpm verify` and clarify push-time checks

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -7,5 +7,7 @@ paths:
 
 ## Push前の検証
 
-git pushを実行する前に、CIと同等の検証をローカルで実行すること。
-コマンドは @.github/workflows/ci-backend.yml を参照。
+git pushを実行する前に、リポジトリルートで **`pnpm verify`** を必ず実行すること
+（lint + Biome `format:check` + type-check + test を app/api 両方）。
+api だけ変更した場合でも、CI の Lint は **eslint と Biome `format:check` の両方**を見るので、
+`pnpm format` で整形してから push する。

--- a/.claude/rules/app.md
+++ b/.claude/rules/app.md
@@ -16,7 +16,13 @@ paths:
 
 ## Push前の検証
 
-git pushを実行する前に、CIと同等の検証をローカルで実行すること。
-コマンドは @.github/workflows/ci-frontend.yml を参照。
+git pushを実行する前に、リポジトリルートで **`pnpm verify`** を必ず実行すること。
+これは CI の Lint ジョブと同じく **eslint だけでなく Biome の `format:check` も含む**
+（lint + format:check + type-check + test を app/api 両方）。eslint だけ通して
+format:check を忘れると CI Lint が落ちる。format 崩れは `pnpm format` で修正できる。
 
-build と e2e はCIに委ねる（ローカル実行は時間がかかるため）。
+UI / 入力まわり（reports・daily-log 等）を変更したら、変更領域の E2E を
+**`pnpm verify:e2e`** で1回ローカル実行する（初回は `pnpm --filter forge-app exec playwright install chromium` が必要）。
+「e2e は CI 委ね」で push するとフィードバックが1往復遅れるので、新規・変更した spec は手元で通しておく。
+
+build と coverage はCIに委ねてよい。

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "format": "biome format --write .",

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && tsc --project tsconfig.worker.json --noEmit && vite build",
+    "type-check": "tsc --noEmit && tsc --project tsconfig.worker.json --noEmit",
     "preview": "vite preview",
     "deploy": "pnpm run build && pnpm exec wrangler deploy",
     "format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "lint": "pnpm --filter forge-app lint && pnpm --filter api lint",
     "lint:fix": "pnpm --filter forge-app lint:fix && pnpm --filter api lint:fix",
     "lint:app": "pnpm --filter forge-app lint",
-    "lint:worker": "pnpm --filter api lint"
+    "lint:worker": "pnpm --filter api lint",
+    "type-check": "pnpm --filter forge-app type-check && pnpm --filter api type-check",
+    "test": "pnpm --filter forge-app test:run && pnpm --filter api test:run",
+    "verify": "pnpm run lint && pnpm run format:check && pnpm run type-check && pnpm run test",
+    "verify:e2e": "pnpm --filter forge-app test:e2e"
   },
   "engines": {
     "node": ">=20.12.0",


### PR DESCRIPTION
push前のCI同等検証を単一コマンド化し、CI Lint(特に Biome format:check) の取りこぼしを防ぐ。

- root: `verify`(lint + format:check + type-check + test / app・api 両方), `verify:e2e`, `type-check`, `test`
- app/api: `type-check`(tsc --noEmit)
- .claude/rules(app/api): 「push前は `pnpm verify`」「Lintは eslint＋Biome format:check の両方」「UI変更は `pnpm verify:e2e`」を明記

背景: 予実/記録機能の作業で、eslint は通したが Biome format:check を回さず CI Lint が落ちた／新規 E2E をローカル実行せず CI で落ちた、を踏まえた再発防止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)